### PR TITLE
Added support for constructorAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Consider this:
 
-```
+```js
 > const a = '{"__proto__":{ "b":5}}';
 '{"__proto__":{ "b":5}}'
 
@@ -29,9 +29,29 @@ The problem is that `JSON.parse()` retains the `__proto__` property as a plain o
 itself, this is not a security issue. However, as soon as that object is assigned to another or
 iterated on and values copied, the `__proto__` property leaks and becomes the object's prototype.
 
+## Install
+```
+npm install secure-json-parse
+```
+
+## Usage
+
+Pass the option object as a second (or third) parameter for configuring the action to take in case of a bad JSON, if nothing is configured, the default is to throw a `SyntaxError`.<br/>
+You can choose which action to perform in case `__proto__` is present, and in case `constructor` is present.
+
+```js
+const sjson = require('secure-json-parse')
+
+const goodJson = '{ "a": 5, "b": 6 }'
+const badJson = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "constructor": {"prototype": {"bar": "baz"} } }'
+
+console.log(JSON.parse(goodJson), sjson.parse(goodJson, { protoAction: 'remove', constructorAction: 'remove' }))
+console.log(JSON.parse(badJson), sjson.parse(badJson, { protoAction: 'remove', constructorAction: 'remove' }))
+```
+
 ## API
 
-### `Bourne.parse(text, [reviver], [options])`
+### `sjson.parse(text, [reviver], [options])`
 
 Parses a given JSON-formatted text into an object where:
 - `text` - the JSON text string.
@@ -41,8 +61,12 @@ Parses a given JSON-formatted text into an object where:
         - `'error'` - throw a `SyntaxError` when a `__proto__` key is found. This is the default value.
         - `'remove'` - deletes any `__proto__` keys from the result object.
         - `'ignore'` - skips all validation (same as calling `JSON.parse()` directly).
+    - `constructorAction` - optional string with one of:
+        - `'error'` - throw a `SyntaxError` when a `constructor` key is found. This is the default value.
+        - `'remove'` - deletes any `constructor` keys from the result object.
+        - `'ignore'` - skips all validation (same as calling `JSON.parse()` directly).
 
-### `Bourne.scan(obj, [options])`
+### `sjson.scan(obj, [options])`
 
 Scans a given object for prototype properties where:
 - `obj` - the object being scanned.
@@ -50,6 +74,9 @@ Scans a given object for prototype properties where:
     - `protoAction` - optional string with one of:
         - `'error'` - throw a `SyntaxError` when a `__proto__` key is found. This is the default value.
         - `'remove'` - deletes any `__proto__` keys from the input `obj`.
+    - `constructorAction` - optional string with one of:
+        - `'error'` - throw a `SyntaxError` when a `constructor` key is found. This is the default value.
+        - `'remove'` - deletes any `constructor` keys from the input `obj`.
 
 # Acknowledgements
 This project has been forked from [hapijs/bourne](https://github.com/hapijs/bourne).

--- a/benchmarks/ignore.js
+++ b/benchmarks/ignore.js
@@ -1,43 +1,32 @@
-'use strict';
+'use strict'
 
-const Benchmark = require('benchmark');
-const Bourne = require('..');
-
+const Benchmark = require('benchmark')
+const Bourne = require('..')
 
 const internals = {
-    text: '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-};
+  text: '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+}
 
-
-const suite = new Benchmark.Suite();
-
+const suite = new Benchmark.Suite()
 
 suite
-    .add('JSON.parse', () => {
-
-        JSON.parse(internals.text);
-    })
-    .add('Bourne.parse', () => {
-
-        Bourne.parse(internals.text, { protoAction: 'ignore' });
-    })
-    .add('reviver', () => {
-
-        JSON.parse(internals.text, internals.reviver);
-    })
-    .on('cycle', (event) => {
-
-        console.log(String(event.target));
-    })
-    .on('complete', function () {
-
-        console.log('Fastest is ' + this.filter('fastest').map('name'));
-    })
-    .run({ async: true });
-
+  .add('JSON.parse', () => {
+    JSON.parse(internals.text)
+  })
+  .add('Bourne.parse', () => {
+    Bourne.parse(internals.text, { protoAction: 'ignore' })
+  })
+  .add('reviver', () => {
+    JSON.parse(internals.text, internals.reviver)
+  })
+  .on('cycle', (event) => {
+    console.log(String(event.target))
+  })
+  .on('complete', function () {
+    console.log('Fastest is ' + this.filter('fastest').map('name'))
+  })
+  .run({ async: true })
 
 internals.reviver = function (key, value) {
-
-    return value;
-};
-
+  return value
+}

--- a/benchmarks/no__proto__.js
+++ b/benchmarks/no__proto__.js
@@ -1,47 +1,37 @@
-'use strict';
+'use strict'
 
-const Benchmark = require('benchmark');
-const Bourne = require('..');
-
+const Benchmark = require('benchmark')
+const Bourne = require('..')
 
 const internals = {
-    text: '{ "a": 5, "b": 6, "proto": { "x": 7 }, "c": { "d": 0, "e": "text", "\\u005f\\u005fproto": { "y": 8 }, "f": { "g": 2 } } }',
-    suspectRx: /"(?:_|\\u005f)(?:_|\\u005f)(?:p|\\u0070)(?:r|\\u0072)(?:o|\\u006f)(?:t|\\u0074)(?:o|\\u006f)(?:_|\\u005f)(?:_|\\u005f)"/
-};
+  text: '{ "a": 5, "b": 6, "proto": { "x": 7 }, "c": { "d": 0, "e": "text", "\\u005f\\u005fproto": { "y": 8 }, "f": { "g": 2 } } }',
+  suspectRx: /"(?:_|\\u005f)(?:_|\\u005f)(?:p|\\u0070)(?:r|\\u0072)(?:o|\\u006f)(?:t|\\u0074)(?:o|\\u006f)(?:_|\\u005f)(?:_|\\u005f)"/
+}
 
-
-const suite = new Benchmark.Suite();
-
+const suite = new Benchmark.Suite()
 
 suite
-    .add('JSON.parse', () => {
-
-        JSON.parse(internals.text);
-    })
-    .add('Bourne.parse', () => {
-
-        Bourne.parse(internals.text);
-    })
-    .add('reviver', () => {
-
-        JSON.parse(internals.text, internals.reviver);
-    })
-    .on('cycle', (event) => {
-
-        console.log(String(event.target));
-    })
-    .on('complete', function () {
-
-        console.log('Fastest is ' + this.filter('fastest').map('name'));
-    })
-    .run({ async: true });
-
+  .add('JSON.parse', () => {
+    JSON.parse(internals.text)
+  })
+  .add('Bourne.parse', () => {
+    Bourne.parse(internals.text)
+  })
+  .add('reviver', () => {
+    JSON.parse(internals.text, internals.reviver)
+  })
+  .on('cycle', (event) => {
+    console.log(String(event.target))
+  })
+  .on('complete', function () {
+    console.log('Fastest is ' + this.filter('fastest').map('name'))
+  })
+  .run({ async: true })
 
 internals.reviver = function (key, value) {
+  if (key.match(internals.suspectRx)) {
+    return undefined
+  }
 
-    if (key.match(internals.suspectRx)) {
-        return undefined;
-    }
-
-    return value;
-};
+  return value
+}

--- a/benchmarks/remove.js
+++ b/benchmarks/remove.js
@@ -1,47 +1,36 @@
-'use strict';
+'use strict'
 
-const Benchmark = require('benchmark');
-const Bourne = require('..');
-
+const Benchmark = require('benchmark')
+const Bourne = require('..')
 
 const internals = {
-    text: '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-};
+  text: '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+}
 
-
-const suite = new Benchmark.Suite();
-
+const suite = new Benchmark.Suite()
 
 suite
-    .add('JSON.parse', () => {
-
-        JSON.parse(internals.text);
-    })
-    .add('Bourne.parse', () => {
-
-        Bourne.parse(internals.text, { protoAction: 'remove' });
-    })
-    .add('reviver', () => {
-
-        JSON.parse(internals.text, internals.reviver);
-    })
-    .on('cycle', (event) => {
-
-        console.log(String(event.target));
-    })
-    .on('complete', function () {
-
-        console.log('Fastest is ' + this.filter('fastest').map('name'));
-    })
-    .run({ async: true });
-
+  .add('JSON.parse', () => {
+    JSON.parse(internals.text)
+  })
+  .add('Bourne.parse', () => {
+    Bourne.parse(internals.text, { protoAction: 'remove' })
+  })
+  .add('reviver', () => {
+    JSON.parse(internals.text, internals.reviver)
+  })
+  .on('cycle', (event) => {
+    console.log(String(event.target))
+  })
+  .on('complete', function () {
+    console.log('Fastest is ' + this.filter('fastest').map('name'))
+  })
+  .run({ async: true })
 
 internals.reviver = function (key, value) {
+  if (key === '__proto__') {
+    return undefined
+  }
 
-    if (key === '__proto__') {
-        return undefined;
-    }
-
-    return value;
-};
-
+  return value
+}

--- a/benchmarks/throw.js
+++ b/benchmarks/throw.js
@@ -1,61 +1,46 @@
-'use strict';
+'use strict'
 
-const Benchmark = require('benchmark');
-const Bourne = require('..');
-
+const Benchmark = require('benchmark')
+const Bourne = require('..')
 
 const internals = {
-    text: '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }',
-    invalid: '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } } }'
-};
+  text: '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }',
+  invalid: '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } } }'
+}
 
-
-const suite = new Benchmark.Suite();
-
+const suite = new Benchmark.Suite()
 
 suite
-    .add('JSON.parse', () => {
-
-        JSON.parse(internals.text);
-    })
-    .add('JSON.parse error', () => {
-
-        try {
-            JSON.parse(internals.invalid);
-        }
-        catch (ignoreErr) { }
-    })
-    .add('Bourne.parse', () => {
-
-        try {
-            Bourne.parse(internals.text);
-        }
-        catch (ignoreErr) { }
-    })
-    .add('reviver', () => {
-
-        try {
-            JSON.parse(internals.text, internals.reviver);
-        }
-        catch (ignoreErr) { }
-    })
-    .on('cycle', (event) => {
-
-        console.log(String(event.target));
-    })
-    .on('complete', function () {
-
-        console.log('Fastest is ' + this.filter('fastest').map('name'));
-    })
-    .run({ async: true });
-
+  .add('JSON.parse', () => {
+    JSON.parse(internals.text)
+  })
+  .add('JSON.parse error', () => {
+    try {
+      JSON.parse(internals.invalid)
+    } catch (ignoreErr) { }
+  })
+  .add('Bourne.parse', () => {
+    try {
+      Bourne.parse(internals.text)
+    } catch (ignoreErr) { }
+  })
+  .add('reviver', () => {
+    try {
+      JSON.parse(internals.text, internals.reviver)
+    } catch (ignoreErr) { }
+  })
+  .on('cycle', (event) => {
+    console.log(String(event.target))
+  })
+  .on('complete', function () {
+    console.log('Fastest is ' + this.filter('fastest').map('name'))
+  })
+  .run({ async: true })
 
 internals.reviver = function (key, value) {
+  if (key === '__proto__') {
+    throw new Error('kaboom')
+  }
 
-    if (key === '__proto__') {
-        throw new Error('kaboom');
-    }
-
-    return value;
-};
-
+  return value
+}

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const suspectProtoRx = /"(?:_|\\u005[Ff])(?:_|\\u005[Ff])(?:p|\\u0070)(?:r|\\u0072)(?:o|\\u006[Ff])(?:t|\\u0074)(?:o|\\u006[Ff])(?:_|\\u005[Ff])(?:_|\\u005[Ff])"\s*:/
-const suspectConstructorRx = /"(?:c|\\u0063)(?:o|\\u006f)(?:n|\\u006e)(?:s|\\u0073)(?:t|\\u0074)(?:r|\\u0072)(?:u|\\u0075)(?:c|\\u0063)(?:t|\\u0074)(?:o|\\u006f)(?:r|\\u0072)"\s*:/
+const suspectConstructorRx = /"(?:c|\\u0063)(?:o|\\u006[Ff])(?:n|\\u006[Ee])(?:s|\\u0073)(?:t|\\u0074)(?:r|\\u0072)(?:u|\\u0075)(?:c|\\u0063)(?:t|\\u0074)(?:o|\\u006[Ff])(?:r|\\u0072)"\s*:/
 
 function parse (text, reviver, options) {
   // Normalize arguments

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function parse (text, reviver, options) {
   }
 
   if (protoAction !== 'ignore' && constructorAction !== 'ignore') {
-    if (!text.match(suspectProtoRx) && !text.match(suspectConstructorRx)) {
+    if (suspectProtoRx.test(text) === false && suspectConstructorRx.test(text) === false) {
       return obj
     }
   } else if (protoAction !== 'ignore' && constructorAction === 'ignore') {

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function scan (obj, { protoAction = 'error', constructorAction = 'error' } = {})
   const protoAction = options.protoAction || 'error'
   const constructorAction = options.constructorAction || 'error'
 
-  var next = [obj]
+  let next = [obj]
 
   while (next.length) {
     const nodes = next

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function parse (text, reviver, options) {
       return obj
     }
   } else {
-    if (!text.match(suspectConstructorRx)) {
+    if (suspectConstructorRx.test(text) === false) {
       return obj
     }
   }

--- a/index.js
+++ b/index.js
@@ -51,9 +51,6 @@ function parse (text, reviver, options) {
 }
 
 function scan (obj, { protoAction = 'error', constructorAction = 'error' } = {}) {
-  const protoAction = options.protoAction || 'error'
-  const constructorAction = options.constructorAction || 'error'
-
   let next = [obj]
 
   while (next.length) {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const suspectConstructorRx = /"(?:c|\\u0063)(?:o|\\u006[Ff])(?:n|\\u006[Ee])(?:s
 function parse (text, reviver, options) {
   // Normalize arguments
   if (options == null) {
-    if (reviver != null && typeof reviver === 'object') {
+    if (reviver !== null && typeof reviver === 'object') {
       options = reviver
       reviver = undefined
     } else {
@@ -26,7 +26,7 @@ function parse (text, reviver, options) {
   }
 
   // Ignore null and non-objects
-  if (!obj || typeof obj !== 'object') {
+  if (obj === null || typeof obj !== 'object') {
     return obj
   }
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function parse (text, reviver, options) {
       return obj
     }
   } else if (protoAction !== 'ignore' && constructorAction === 'ignore') {
-    if (!text.match(suspectProtoRx)) {
+    if (suspectProtoRx.test(text) === false) {
       return obj
     }
   } else {

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function scan (obj, { protoAction = 'error', constructorAction = 'error' } = {})
           throw new SyntaxError('Object contains forbidden prototype property')
         }
 
-        delete node.__proto__ // eslint-disable-line
+        delete node.__proto__ // eslint-disable-line no-proto
       }
 
       if (constructorAction !== 'ignore' && Object.prototype.hasOwnProperty.call(node, 'constructor')) { // Avoid calling node.hasOwnProperty directly

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function parse (text, reviver, options) {
   return obj
 }
 
-function scan (obj, options = {}) {
+function scan (obj, { protoAction = 'error', constructorAction = 'error' } = {}) {
   const protoAction = options.protoAction || 'error'
   const constructorAction = options.constructorAction || 'error'
 

--- a/package.json
+++ b/package.json
@@ -4,21 +4,27 @@
   "description": "JSON parse with prototype poisoning protection",
   "main": "index.js",
   "scripts": {
-    "test": "tap test.js"
+    "test": "standard && tap test.js"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fastify/secure-json-parse.git"
   },
-  "keywords": [],
+  "keywords": [
+    "JSON",
+    "parse",
+    "safe",
+    "security",
+    "prototype",
+    "pollution"
+  ],
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/fastify/secure-json-parse/issues"
   },
   "homepage": "https://github.com/fastify/secure-json-parse#readme",
-  "dependencies": {},
   "devDependencies": {
-    "standard": "^12.0.1",
+    "standard": "^14.3.1",
     "tap": "^12.7.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -223,6 +223,8 @@ test('parse', t => {
       t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006fnstructor": {"prototype":{"bar":"baz"}} }'), SyntaxError)
       t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006f\\u006e\\u0073\\u0074ructor": {"prototype":{"bar":"baz"}} }'), SyntaxError)
       t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006f\\u006e\\u0073\\u0074\\u0072\\u0075\\u0063\\u0074\\u006f\\u0072": {"prototype":{"bar":"baz"}} }'), SyntaxError)
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006Fnstructor": {"prototype":{"bar":"baz"}} }'), SyntaxError)
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006F\\u006E\\u0073\\u0074\\u0072\\u0075\\u0063\\u0074\\u006F\\u0072": {"prototype":{"bar":"baz"}} }'), SyntaxError)
       t.end()
     })
 

--- a/test.js
+++ b/test.js
@@ -48,91 +48,256 @@ test('parse', t => {
     t.end()
   })
 
-  t.test('sanitizes object string (reviver, options)', t => {
-    const reviver = (key, value) => {
-      return typeof value === 'number' ? value + 1 : value
-    }
+  t.test('protoAction', t => {
+    t.test('sanitizes object string (reviver, options)', t => {
+      const reviver = (key, value) => {
+        return typeof value === 'number' ? value + 1 : value
+      }
 
-    t.deepEqual(
-      j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', reviver, { protoAction: 'remove' }),
-      { a: 6, b: 7 }
-    )
+      t.deepEqual(
+        j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', reviver, { protoAction: 'remove' }),
+        { a: 6, b: 7 }
+      )
+      t.end()
+    })
+
+    t.test('sanitizes object string (options)', t => {
+      t.deepEqual(
+        j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', { protoAction: 'remove' }),
+        { a: 5, b: 6 }
+      )
+      t.end()
+    })
+
+    t.test('sanitizes object string (null, options)', t => {
+      t.deepEqual(
+        j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', null, { protoAction: 'remove' }),
+        { a: 5, b: 6 }
+      )
+      t.end()
+    })
+
+    t.test('sanitizes object string (null, options)', t => {
+      t.deepEqual(
+        j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', { protoAction: 'remove' }),
+        { a: 5, b: 6 }
+      )
+      t.end()
+    })
+
+    t.test('sanitizes nested object string', t => {
+      t.deepEqual(
+        j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }', { protoAction: 'remove' }),
+        { a: 5, b: 6, c: { d: 0, e: 'text', f: { g: 2 } } }
+      )
+      t.end()
+    })
+
+    t.test('ignores proto property', t => {
+      t.deepEqual(
+        j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }', { protoAction: 'ignore' }),
+        JSON.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }')
+      )
+      t.end()
+    })
+
+    t.test('ignores proto value', t => {
+      t.deepEqual(
+        j.parse('{"a": 5, "b": "__proto__"}'),
+        { a: 5, b: '__proto__' }
+      )
+      t.end()
+    })
+
+    t.test('errors on proto property', t => {
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'), SyntaxError)
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__" : { "x": 7 } }'), SyntaxError)
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__" \n\r\t : { "x": 7 } }'), SyntaxError)
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__" \n \r \t : { "x": 7 } }'), SyntaxError)
+      t.end()
+    })
+
+    t.test('errors on proto property (null, null)', t => {
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }', null, null), SyntaxError)
+      t.end()
+    })
+
+    t.test('errors on proto property (explicit options)', t => {
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }', { protoAction: 'error' }), SyntaxError)
+      t.end()
+    })
+
+    t.test('errors on proto property (unicode)', t => {
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005f_proto__": { "x": 7 } }'), SyntaxError)
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "_\\u005fp\\u0072oto__": { "x": 7 } }'), SyntaxError)
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005f\\u005f\\u0070\\u0072\\u006f\\u0074\\u006f\\u005f\\u005f": { "x": 7 } }'), SyntaxError)
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005F_proto__": { "x": 7 } }'), SyntaxError)
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "_\\u005Fp\\u0072oto__": { "x": 7 } }'), SyntaxError)
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005F\\u005F\\u0070\\u0072\\u006F\\u0074\\u006F\\u005F\\u005F": { "x": 7 } }'), SyntaxError)
+      t.end()
+    })
+
     t.end()
   })
 
-  t.test('sanitizes object string (options)', t => {
-    t.deepEqual(
-      j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', { protoAction: 'remove' }),
-      { a: 5, b: 6 }
-    )
+  t.test('constructorAction', t => {
+    t.test('sanitizes object string (reviver, options)', t => {
+      const reviver = (key, value) => {
+        return typeof value === 'number' ? value + 1 : value
+      }
+
+      t.deepEqual(
+        j.parse('{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }', reviver, { constructorAction: 'remove' }),
+        { a: 6, b: 7 }
+      )
+      t.end()
+    })
+
+    t.test('sanitizes object string (options)', t => {
+      t.deepEqual(
+        j.parse('{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }', { constructorAction: 'remove' }),
+        { a: 5, b: 6 }
+      )
+      t.end()
+    })
+
+    t.test('sanitizes object string (null, options)', t => {
+      t.deepEqual(
+        j.parse('{"a": 5, "b": 6,"constructor":{"prototype":{"bar":"baz"}} }', null, { constructorAction: 'remove' }),
+        { a: 5, b: 6 }
+      )
+      t.end()
+    })
+
+    t.test('sanitizes object string (null, options)', t => {
+      t.deepEqual(
+        j.parse('{"a": 5, "b": 6,"constructor":{"prototype":{"bar":"baz"}} }', { constructorAction: 'remove' }),
+        { a: 5, b: 6 }
+      )
+      t.end()
+    })
+
+    t.test('sanitizes nested object string', t => {
+      t.deepEqual(
+        j.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "c": { "d": 0, "e": "text", "constructor":{"prototype":{"bar":"baz"}}, "f": { "g": 2 } } }', { constructorAction: 'remove' }),
+        { a: 5, b: 6, c: { d: 0, e: 'text', f: { g: 2 } } }
+      )
+      t.end()
+    })
+
+    t.test('ignores proto property', t => {
+      t.deepEqual(
+        j.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }', { constructorAction: 'ignore' }),
+        JSON.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }')
+      )
+      t.end()
+    })
+
+    t.test('ignores proto value', t => {
+      t.deepEqual(
+        j.parse('{"a": 5, "b": "constructor"}'),
+        { a: 5, b: 'constructor' }
+      )
+      t.end()
+    })
+
+    t.test('errors on proto property', t => {
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "constructor": {"prototype":{"bar":"baz"}} }'), SyntaxError)
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "constructor" : {"prototype":{"bar":"baz"}} }'), SyntaxError)
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "constructor" \n\r\t : {"prototype":{"bar":"baz"}} }'), SyntaxError)
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "constructor" \n \r \t : {"prototype":{"bar":"baz"}} }'), SyntaxError)
+      t.end()
+    })
+
+    t.test('errors on proto property (null, null)', t => {
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }', null, null), SyntaxError)
+      t.end()
+    })
+
+    t.test('errors on proto property (explicit options)', t => {
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }', { constructorAction: 'error' }), SyntaxError)
+      t.end()
+    })
+
+    t.test('errors on proto property (unicode)', t => {
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006fnstructor": {"prototype":{"bar":"baz"}} }'), SyntaxError)
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006f\\u006e\\u0073\\u0074ructor": {"prototype":{"bar":"baz"}} }'), SyntaxError)
+      t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006f\\u006e\\u0073\\u0074\\u0072\\u0075\\u0063\\u0074\\u006f\\u0072": {"prototype":{"bar":"baz"}} }'), SyntaxError)
+      t.end()
+    })
+
     t.end()
   })
 
-  t.test('sanitizes object string (null, options)', t => {
-    t.deepEqual(
-      j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', null, { protoAction: 'remove' }),
-      { a: 5, b: 6 }
-    )
-    t.end()
-  })
+  t.test('protoAction and constructorAction', t => {
+    t.test('protoAction=remove constructorAction=remove', t => {
+      t.deepEqual(
+        j.parse(
+          '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
+          { protoAction: 'remove', constructorAction: 'remove' }
+        ),
+        { a: 5, b: 6 }
+      )
+      t.end()
+    })
 
-  t.test('sanitizes object string (null, options)', t => {
-    t.deepEqual(
-      j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', { protoAction: 'remove' }),
-      { a: 5, b: 6 }
-    )
-    t.end()
-  })
+    t.test('protoAction=ignore constructorAction=remove', t => {
+      t.deepEqual(
+        j.parse(
+          '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
+          { protoAction: 'ignore', constructorAction: 'remove' }
+        ),
+        JSON.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }')
+      )
+      t.end()
+    })
 
-  t.test('sanitizes nested object string', t => {
-    t.deepEqual(
-      j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }', { protoAction: 'remove' }),
-      { a: 5, b: 6, c: { d: 0, e: 'text', f: { g: 2 } } }
-    )
-    t.end()
-  })
+    t.test('protoAction=remove constructorAction=ignore', t => {
+      t.deepEqual(
+        j.parse(
+          '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
+          { protoAction: 'remove', constructorAction: 'ignore' }
+        ),
+        JSON.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }')
+      )
+      t.end()
+    })
 
-  t.test('ignores proto property', t => {
-    t.deepEqual(
-      j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }', { protoAction: 'ignore' }),
-      JSON.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }')
-    )
-    t.end()
-  })
+    t.test('protoAction=ignore constructorAction=ignore', t => {
+      t.deepEqual(
+        j.parse(
+          '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
+          { protoAction: 'ignore', constructorAction: 'ignore' }
+        ),
+        JSON.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }')
+      )
+      t.end()
+    })
 
-  t.test('ignores proto value', t => {
-    t.deepEqual(
-      j.parse('{"a": 5, "b": "__proto__"}'),
-      { a: 5, b: '__proto__' }
-    )
-    t.end()
-  })
+    t.test('protoAction=error constructorAction=ignore', t => {
+      t.throws(() => j.parse(
+        '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
+        { protoAction: 'error', constructorAction: 'ignore' }
+      ), SyntaxError)
+      t.end()
+    })
 
-  t.test('errors on proto property', t => {
-    t.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'), SyntaxError)
-    t.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__" : { "x": 7 } }'), SyntaxError)
-    t.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__" \n\r\t : { "x": 7 } }'), SyntaxError)
-    t.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__" \n \r \t : { "x": 7 } }'), SyntaxError)
-    t.end()
-  })
+    t.test('protoAction=ignore constructorAction=error', t => {
+      t.throws(() => j.parse(
+        '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
+        { protoAction: 'ignore', constructorAction: 'error' }
+      ), SyntaxError)
+      t.end()
+    })
 
-  t.test('errors on proto property (null, null)', t => {
-    t.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }', null, null), SyntaxError)
-    t.end()
-  })
+    t.test('protoAction=error constructorAction=error', t => {
+      t.throws(() => j.parse(
+        '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
+        { protoAction: 'error', constructorAction: 'error' }
+      ), SyntaxError)
+      t.end()
+    })
 
-  t.test('errors on proto property (explicit options)', t => {
-    t.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }', { protoAction: 'error' }), SyntaxError)
-    t.end()
-  })
-
-  t.test('errors on proto property (unicode)', t => {
-    t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005f_proto__": { "x": 7 } }'), SyntaxError)
-    t.throws(() => j.parse('{ "a": 5, "b": 6, "_\\u005fp\\u0072oto__": { "x": 7 } }'), SyntaxError)
-    t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005f\\u005f\\u0070\\u0072\\u006f\\u0074\\u006f\\u005f\\u005f": { "x": 7 } }'), SyntaxError)
-    t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005F_proto__": { "x": 7 } }'), SyntaxError)
-    t.throws(() => j.parse('{ "a": 5, "b": 6, "_\\u005Fp\\u0072oto__": { "x": 7 } }'), SyntaxError)
-    t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005F\\u005F\\u0070\\u0072\\u006F\\u0074\\u006F\\u005F\\u005F": { "x": 7 } }'), SyntaxError)
     t.end()
   })
 


### PR DESCRIPTION
As titled.
Now the following code is supported as well:
```js
t.deepEqual(
  j.parse(
    '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
      { protoAction: 'remove', constructorAction: 'remove' }
  ),
  { a: 5, b: 6 }
)
```

cc @watson

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
