### PR TITLE
Ignore BOM char

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,11 @@ function parse (text, reviver, options) {
   const protoAction = options.protoAction || 'error'
   const constructorAction = options.constructorAction || 'error'
 
+  // BOM checker
+  if (text && text.charCodeAt(0) === 0xFEFF) {
+    text = text.slice(1)
+  }
+
   // Parse normally, allowing exceptions
   const obj = JSON.parse(text, reviver)
 

--- a/test.js
+++ b/test.js
@@ -363,3 +363,13 @@ test('safeParse', t => {
 
   t.end()
 })
+
+test('parse string with BOM', t => {
+  const theJson = { hello: 'world' }
+  const buffer = Buffer.concat([
+    Buffer.from([239, 187, 191]), // the utf8 BOM
+    Buffer.from(JSON.stringify(theJson))
+  ])
+  t.deepEqual(j.parse(buffer.toString()), theJson)
+  t.end()
+})


### PR DESCRIPTION
Opening this PR because in some context (eg old proxies) the BOM is appended to the body object sent to a fastify server that will cause an HTTP 500.

With the BOM char the `JSON.parse` fail, so I would add this check since the Unicode Standard permits the BOM in UTF-8, but is not meaningful in a UTF-8 scenario (like node.js).

The buffer in the test equals to the [EF BB EF](https://en.wikipedia.org/wiki/Byte_order_mark#Byte_order_marks_by_encoding) that the buffer-to-string translates to [FEFF (UTF-16 BOM)](https://www.fileformat.info/info/unicode/char/feff/index.htm)

A little snippet:
```
const bom = Buffer.from([239, 187, 191])
console.log(bom.toString().charCodeAt(0))
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
