### PR TITLE
fix: support parsing buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,10 @@ function parse (text, reviver, options) {
   const protoAction = options.protoAction || 'error'
   const constructorAction = options.constructorAction || 'error'
 
+  if (Buffer.isBuffer(text)) {
+    text = text.toString()
+  }
+
   // BOM checker
   if (text && text.charCodeAt(0) === 0xFEFF) {
     text = text.slice(1)

--- a/test.js
+++ b/test.js
@@ -36,6 +36,14 @@ test('parse', t => {
     t.end()
   })
 
+  t.test('parses buffer', t => {
+    t.strictEqual(
+      j.parse(Buffer.from('"X"')),
+      JSON.parse(Buffer.from('"X"'))
+    )
+    t.end()
+  })
+
   t.test('parses object string (reviver)', t => {
     const reviver = (key, value) => {
       return typeof value === 'number' ? value + 1 : value
@@ -371,5 +379,15 @@ test('parse string with BOM', t => {
     Buffer.from(JSON.stringify(theJson))
   ])
   t.deepEqual(j.parse(buffer.toString()), theJson)
+  t.end()
+})
+
+test('parse buffer with BOM', t => {
+  const theJson = { hello: 'world' }
+  const buffer = Buffer.concat([
+    Buffer.from([239, 187, 191]), // the utf8 BOM
+    Buffer.from(JSON.stringify(theJson))
+  ])
+  t.deepEqual(j.parse(buffer), theJson)
   t.end()
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added (no changes needed)*
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


# Summary

When `parse` is called with a Buffer, an error was being thrown because we were attempting to call text.charCodeAt which doesn't exist for buffers. This simply adds a check if charCodeAt exists before attempting to invoke it.