### PR TITLE
Switch testing to tape

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -5,4 +5,4 @@ update_configs:
     update_schedule: "daily"
     ignored_updates:
       - match:
-          dependency_name: "tap"
+          dependency_name: "tape"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "benchmark": "cd benchmarks && npm install && npm run all",
-    "test": "standard && tap test.js"
+    "test": "standard && tape test.js"
   },
   "repository": {
     "type": "git",
@@ -26,6 +26,6 @@
   "homepage": "https://github.com/fastify/secure-json-parse#readme",
   "devDependencies": {
     "standard": "^16.0.0",
-    "tap": "^12.7.0"
+    "tape": "^5.1.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const test = require('tape').test
 const j = require('./index')
 
 test('parse', t => {


### PR DESCRIPTION
This is primarily to support a future addition of airtap which relies on tape and from limited testing does not work with tap.

Both projects seem to be supported and popular, the API similar, it seems the primary way of choosing between the two is a matter of taste and required advanced functionality. ([example](https://github.com/denis-sokolov/secure-json-parse/pull/new/tape))

Our existing suite works fine with both, we do not rely on any advanced functionality.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
