### PR TITLE
Use npm ci in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
-      run: npm install --ignore-scripts
+      run: npm ci --ignore-scripts
     - name: Test
       run: npm run test


### PR DESCRIPTION
`npm ci` is meant to install the dependencies from scratch in a CI environment, relying only on a lockfile. This is supposed to be faster and has a side-effect of validating the lockfile is up-to-date.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
