### PR TITLE
Add testing in browsers

### DIFF
--- a/.airtap.yml
+++ b/.airtap.yml
@@ -1,0 +1,7 @@
+providers:
+  - airtap-playwright
+
+browsers:
+  - name: chromium
+    supports:
+      headless: true

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,6 +3,3 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "daily"
-    ignored_updates:
-      - match:
-          dependency_name: "tap"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,15 @@
 name: CI workflow
 on: [push, pull_request]
 jobs:
+  browsers:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+    - name: Install Dependencies
+      run: npm install
+    - name: Test
+      run: npm run test-in-browsers
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 **/node_modules
 **/package-lock.json
 
-coverage.*
+/.nyc_output
 
 **/.DS_Store
 **/._*

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "benchmark": "cd benchmarks && npm install && npm run all",
-    "test": "standard && tap test.js"
+    "test": "standard && tape test.js"
   },
   "repository": {
     "type": "git",
@@ -26,6 +26,6 @@
   "homepage": "https://github.com/fastify/secure-json-parse#readme",
   "devDependencies": {
     "standard": "^16.0.0",
-    "tap": "^12.7.0"
+    "tape": "^5.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "benchmark": "cd benchmarks && npm install && npm run all",
-    "test": "standard && tape test.js",
+    "test": "standard && nyc tape test.js",
     "test-in-browsers": "airtap test.js"
   },
   "repository": {
@@ -28,6 +28,7 @@
   "devDependencies": {
     "airtap": "^4.0.1",
     "airtap-playwright": "^1.0.1",
+    "nyc": "^14.1.1",
     "playwright": "^1.7.1",
     "standard": "^16.0.0",
     "tape": "^5.1.1"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "benchmark": "cd benchmarks && npm install && npm run all",
-    "test": "standard && tape test.js"
+    "test": "standard && tape test.js",
+    "test-in-browsers": "airtap test.js"
   },
   "repository": {
     "type": "git",
@@ -25,6 +26,9 @@
   },
   "homepage": "https://github.com/fastify/secure-json-parse#readme",
   "devDependencies": {
+    "airtap": "^4.0.1",
+    "airtap-playwright": "^1.0.1",
+    "playwright": "^1.7.1",
     "standard": "^16.0.0",
     "tape": "^5.1.1"
   }

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const test = require('tape').test
 const j = require('./index')
 
 test('parse', t => {


### PR DESCRIPTION
As per conversation in #15, added airtap for test running in the browsers.

The diff includes changes from PRs #16, #18, #20, please wait for those to be merged for the diff to be nicer.

Ironically, these tests do not catch the Buffer issue that #15 fixes. During the bundling for testing, airtap uses Browserify, which packages a Buffer polyfill in. I could not find a way to disable that and keep the rest of the tooling working. But unrelated to #15, perhaps this tooling is beneficial for the project.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
