### PR TITLE
Throw only if the constructor key has a child named prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install secure-json-parse
 ## Usage
 
 Pass the option object as a second (or third) parameter for configuring the action to take in case of a bad JSON, if nothing is configured, the default is to throw a `SyntaxError`.<br/>
-You can choose which action to perform in case `__proto__` is present, and in case `constructor` is present.
+You can choose which action to perform in case `__proto__` is present, and in case `constructor.prototype` is present.
 
 ```js
 const sjson = require('secure-json-parse')
@@ -63,7 +63,7 @@ Parses a given JSON-formatted text into an object where:
         - `'remove'` - deletes any `__proto__` keys from the result object.
         - `'ignore'` - skips all validation (same as calling `JSON.parse()` directly).
     - `constructorAction` - optional string with one of:
-        - `'error'` - throw a `SyntaxError` when a `constructor` key is found. This is the default value.
+        - `'error'` - throw a `SyntaxError` when a `constructor.prototype` key is found. This is the default value.
         - `'remove'` - deletes any `constructor` keys from the result object.
         - `'ignore'` - skips all validation (same as calling `JSON.parse()` directly).
 
@@ -76,7 +76,7 @@ Scans a given object for prototype properties where:
         - `'error'` - throw a `SyntaxError` when a `__proto__` key is found. This is the default value.
         - `'remove'` - deletes any `__proto__` keys from the input `obj`.
     - `constructorAction` - optional string with one of:
-        - `'error'` - throw a `SyntaxError` when a `constructor` key is found. This is the default value.
+        - `'error'` - throw a `SyntaxError` when a `constructor.prototype` key is found. This is the default value.
         - `'remove'` - deletes any `constructor` keys from the input `obj`.
 
 ## Benchmarks

--- a/index.js
+++ b/index.js
@@ -76,7 +76,9 @@ function scan (obj, { protoAction = 'error', constructorAction = 'error' } = {})
         delete node.__proto__ // eslint-disable-line no-proto
       }
 
-      if (constructorAction !== 'ignore' && Object.prototype.hasOwnProperty.call(node, 'constructor')) { // Avoid calling node.hasOwnProperty directly
+      if (constructorAction !== 'ignore' &&
+          Object.prototype.hasOwnProperty.call(node, 'constructor') &&
+          Object.prototype.hasOwnProperty.call(node.constructor, 'prototype')) { // Avoid calling node.hasOwnProperty directly
         if (constructorAction === 'error') {
           throw new SyntaxError('Object contains forbidden prototype property')
         }

--- a/test.js
+++ b/test.js
@@ -185,6 +185,14 @@ test('parse', t => {
       t.end()
     })
 
+    t.test('sanitizes object string (no prototype key)', t => {
+      t.deepEqual(
+        j.parse('{"a": 5, "b": 6,"constructor":{"bar":"baz"} }', { constructorAction: 'remove' }),
+        { a: 5, b: 6, constructor: { bar: 'baz' } }
+      )
+      t.end()
+    })
+
     t.test('sanitizes nested object string', t => {
       t.deepEqual(
         j.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "c": { "d": 0, "e": "text", "constructor":{"prototype":{"bar":"baz"}}, "f": { "g": 2 } } }', { constructorAction: 'remove' }),
@@ -214,6 +222,11 @@ test('parse', t => {
       t.throws(() => j.parse('{ "a": 5, "b": 6, "constructor" : {"prototype":{"bar":"baz"}} }'), SyntaxError)
       t.throws(() => j.parse('{ "a": 5, "b": 6, "constructor" \n\r\t : {"prototype":{"bar":"baz"}} }'), SyntaxError)
       t.throws(() => j.parse('{ "a": 5, "b": 6, "constructor" \n \r \t : {"prototype":{"bar":"baz"}} }'), SyntaxError)
+      t.end()
+    })
+
+    t.test('Should not throw if the constructor key hasn\'t a child named prototype', t => {
+      t.doesNotThrow(() => j.parse('{ "a": 5, "b": 6, "constructor":{"bar":"baz"} }', null, null), SyntaxError)
       t.end()
     })
 


### PR DESCRIPTION
Currently, we are throwing an error for a valid use case, eg:
```json
{
  "constructor": {
    "foo": "bar
  }
}
```
While we should only throw if the constructor key has a direct `prototype` child.
```json
{
  "constructor": {
    "prototype": {
      "foo": "bar
    }
  }
}
```

I'm still checking if there are some edge cases that need to be covered, or if this change will introduce any regression.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
