### PR TITLE
perf: Improve performance of safeParse in case of malicious payload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Dependencies
         run: npm install
       - name: Test
-        run: npm run test-in-browsers
+        run: npm run test:browsers
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -56,7 +56,7 @@ jobs:
       - name: Install Dependencies
         run: npm install --ignore-scripts
       - name: Test
-        run: npm run test-legacy
+        run: npm run test:legacy
   automerge:
     needs:
       - browsers

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/benchmarks/.npmrc
+++ b/benchmarks/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/benchmarks/ignore.js
+++ b/benchmarks/ignore.js
@@ -13,8 +13,11 @@ suite
   .add('JSON.parse', () => {
     JSON.parse(internals.text)
   })
-  .add('secure-json-parse', () => {
+  .add('secure-json-parse parse', () => {
     sjson.parse(internals.text, { protoAction: 'ignore' })
+  })
+  .add('secure-json-parse safeParse', () => {
+    sjson.safeParse(internals.text)
   })
   .add('reviver', () => {
     JSON.parse(internals.text, internals.reviver)

--- a/benchmarks/no__proto__.js
+++ b/benchmarks/no__proto__.js
@@ -14,8 +14,11 @@ suite
   .add('JSON.parse', () => {
     JSON.parse(internals.text)
   })
-  .add('secure-json-parse', () => {
+  .add('secure-json-parse parse', () => {
     sjson.parse(internals.text)
+  })
+  .add('secure-json-parse safeParse', () => {
+    sjson.safeParse(internals.text)
   })
   .add('reviver', () => {
     JSON.parse(internals.text, internals.reviver)

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -2,11 +2,12 @@
   "name": "benchmarks",
   "version": "1.0.0",
   "scripts": {
+    "valid": "node valid.js",
     "ignore": "node ignore.js",
     "no_proto": "node no__proto__.js",
     "remove": "node remove.js",
     "throw": "node throw.js",
-    "all": "node --version && npm run ignore && npm run no_proto && npm run remove && npm run throw"
+    "all": "node --version && npm run ignore && npm run no_proto && npm run remove && npm run throw && npm run valid"
   },
   "dependencies": {
     "benchmark": "^2.1.4"

--- a/benchmarks/remove.js
+++ b/benchmarks/remove.js
@@ -13,8 +13,11 @@ suite
   .add('JSON.parse', () => {
     JSON.parse(internals.text)
   })
-  .add('secure-json-parse', () => {
+  .add('secure-json-parse parse', () => {
     sjson.parse(internals.text, { protoAction: 'remove' })
+  })
+  .add('secure-json-parse safeParse', () => {
+    sjson.safeParse(internals.text)
   })
   .add('reviver', () => {
     JSON.parse(internals.text, internals.reviver)

--- a/benchmarks/valid.js
+++ b/benchmarks/valid.js
@@ -4,7 +4,8 @@ const Benchmark = require('benchmark')
 const sjson = require('..')
 
 const internals = {
-  text: '{ "a": 5, "b": 6, "c": { "d": 0, "e": "text", "f": { "g": 2 } } }'
+  text: '{ "a": 5, "b": 6, "c": { "d": 0, "e": "text", "f": { "g": 2 } } }',
+  proto: '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }',
 }
 
 const suite = new Benchmark.Suite()
@@ -13,11 +14,20 @@ suite
   .add('JSON.parse', () => {
     JSON.parse(internals.text)
   })
+  .add('JSON.parse proto', () => {
+    JSON.parse(internals.proto)
+  })
   .add('secure-json-parse parse', () => {
     sjson.parse(internals.text)
   })
+  .add('secure-json-parse parse proto', () => {
+    sjson.parse(internals.text, { constructorAction: 'ignore', protoAction: 'ignore'})
+  })
   .add('secure-json-parse safeParse', () => {
     sjson.safeParse(internals.text)
+  })
+  .add('secure-json-parse safeParse proto', () => {
+    sjson.safeParse(internals.proto)
   })
   .add('JSON.parse reviver', () => {
     JSON.parse(internals.text, internals.reviver)

--- a/benchmarks/valid.js
+++ b/benchmarks/valid.js
@@ -5,7 +5,7 @@ const sjson = require('..')
 
 const internals = {
   text: '{ "a": 5, "b": 6, "c": { "d": 0, "e": "text", "f": { "g": 2 } } }',
-  proto: '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }',
+  proto: '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
 }
 
 const suite = new Benchmark.Suite()
@@ -21,7 +21,7 @@ suite
     sjson.parse(internals.text)
   })
   .add('secure-json-parse parse proto', () => {
-    sjson.parse(internals.text, { constructorAction: 'ignore', protoAction: 'ignore'})
+    sjson.parse(internals.text, { constructorAction: 'ignore', protoAction: 'ignore' })
   })
   .add('secure-json-parse safeParse', () => {
     sjson.safeParse(internals.text)

--- a/benchmarks/valid.js
+++ b/benchmarks/valid.js
@@ -4,8 +4,7 @@ const Benchmark = require('benchmark')
 const sjson = require('..')
 
 const internals = {
-  text: '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }',
-  invalid: '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } } }'
+  text: '{ "a": 5, "b": 6, "c": { "d": 0, "e": "text", "f": { "g": 2 } } }'
 }
 
 const suite = new Benchmark.Suite()
@@ -14,23 +13,14 @@ suite
   .add('JSON.parse', () => {
     JSON.parse(internals.text)
   })
-  .add('JSON.parse error', () => {
-    try {
-      JSON.parse(internals.invalid)
-    } catch (ignoreErr) { }
-  })
   .add('secure-json-parse parse', () => {
-    try {
-      sjson.parse(internals.text)
-    } catch (ignoreErr) { }
+    sjson.parse(internals.text)
   })
   .add('secure-json-parse safeParse', () => {
     sjson.safeParse(internals.text)
   })
-  .add('reviver', () => {
-    try {
-      JSON.parse(internals.text, internals.reviver)
-    } catch (ignoreErr) { }
+  .add('JSON.parse reviver', () => {
+    JSON.parse(internals.text, internals.reviver)
   })
   .on('cycle', (event) => {
     console.log(String(event.target))
@@ -42,7 +32,7 @@ suite
 
 internals.reviver = function (key, value) {
   if (key === '__proto__') {
-    throw new Error('kaboom')
+    return undefined
   }
 
   return value

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,29 +5,14 @@ export type ParseOptions = {
     * - `'remove'` - deletes any `__proto__` keys from the result object.
     * - `'ignore'` - skips all validation (same as calling `JSON.parse()` directly).
     */
-  protoAction?: 'error' | 'remove' | 'ignore',
+  protoAction?: 'error' | 'remove' | 'ignore';
   /**
    * What to do when a `constructor` key is found.
    * - `'error'` - throw a `SyntaxError` when a `constructor.prototype` key is found. This is the default value.
    * - `'remove'` - deletes any `constructor` keys from the result object.
    * - `'ignore'` - skips all validation (same as calling `JSON.parse()` directly).
    */
-  constructorAction?: 'error' | 'remove' | 'ignore',
-}
-
-export type ScanOptions = {
-  /**
-   * What to do when a `__proto__` key is found.
-    * - `'error'` - throw a `SyntaxError` when a `__proto__` key is found. This is the default value.
-    * - `'remove'` - deletes any `__proto__` keys from the input `obj`.
-    */
-  protoAction?: 'error' | 'remove',
-  /**
-   * What to do when a `constructor` key is found.
-   * - `'error'` - throw a `SyntaxError` when a `constructor.prototype` key is found. This is the default value.
-   * - `'remove'` - deletes any `constructor` keys from the input `obj`.
-   */
-  constructorAction?: 'error' | 'remove',
+  constructorAction?: 'error' | 'remove' | 'ignore';
 }
 
 type Reviver = (this: any, key: string, value: any) => any
@@ -40,7 +25,8 @@ type Reviver = (this: any, key: string, value: any) => any
  * @param options Optional configuration object.
  * @returns The parsed object.
  */
-export function parse(text: string | Buffer, reviver?: Reviver | null, options?: ParseOptions): any
+export function parse(text: string | Buffer, reviver: Reviver | null, options?: ParseOptions): any
+export function parse(text: string | Buffer, options?: ParseOptions): any
 
 /**
  * Parses a given JSON-formatted text into an object.
@@ -50,11 +36,3 @@ export function parse(text: string | Buffer, reviver?: Reviver | null, options?:
  * @returns The parsed object, or `null` if there was an error or if the JSON contained possibly insecure properties.
  */
 export function safeParse(text: string | Buffer, reviver?: Reviver | null): any
-
-/**
- * Scans a given object for prototype properties.
- *
- * @param obj The object being scanned.
- * @param options Optional configuration object.
- */
-export function scan(obj: any, options?: ScanOptions): void

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,8 +1,10 @@
 import { expectType, expectError } from 'tsd'
-import sjson = require('.')
+import sjson from "."
 
 expectError(sjson.parse(null))
 expectType<any>(sjson.parse('{"anything":0}'))
+sjson.parse('"test"', { constructorAction: 'error' })
+sjson.parse('"test"', null, { constructorAction: 'error' })
 
 sjson.parse('"test"', null, { protoAction: 'remove' })
 expectError(sjson.parse('"test"', null, { protoAction: 'incorrect' }))
@@ -12,11 +14,6 @@ expectError(sjson.parse('"test"', null, { constructorAction: 'incorrect' }))
 sjson.safeParse('"test"', null)
 sjson.safeParse('"test"')
 expectError(sjson.safeParse(null))
-
-sjson.scan('"test"', { protoAction: 'remove' })
-expectError(sjson.scan('"test"', { protoAction: 'ignore' }))
-sjson.scan('"test"', { constructorAction: 'error' })
-expectError(sjson.scan('"test"', { constructorAction: 'ignore' }))
 
 declare const input: Buffer
 sjson.parse(input)

--- a/package.json
+++ b/package.json
@@ -6,9 +6,12 @@
   "types": "index.d.ts",
   "scripts": {
     "benchmark": "cd benchmarks && npm install && npm run all",
-    "test": "standard && tsd && nyc tape test.js",
-    "test-in-browsers": "airtap test.js",
-    "test-legacy": "nyc tape test.js"
+    "lint": "standard",
+    "test": "npm run test:types && npm run test:unit:coverage",
+    "test:unit": "tape test.js",
+    "test:unit:coverage": "nyc npm run test:unit",
+    "test:types": "tsd",
+    "test:browsers": "airtap test.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -353,7 +353,6 @@ test('parse', t => {
     t.end()
   })
 
-
   t.test('does not break when hasOwnProperty is overwritten', t => {
     const text = '{ "a": 5, "b": 6, "hasOwnProperty": "text", "__proto__": { "x": 7 } }'
 

--- a/test.js
+++ b/test.js
@@ -324,40 +324,83 @@ test('parse', t => {
     t.end()
   })
 
-  t.end()
-})
-
-test('scan', t => {
   t.test('sanitizes nested object string', t => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-    const obj = JSON.parse(text)
 
-    j.scan(obj, { protoAction: 'remove' })
+    const obj = j.parse(text, { protoAction: 'remove' })
     t.deepEqual(obj, { a: 5, b: 6, c: { d: 0, e: 'text', f: { g: 2 } } })
+    t.end()
+  })
+
+  t.test('errors on constructor property', t => {
+    const text = '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+
+    t.throws(() => j.parse(text), SyntaxError)
     t.end()
   })
 
   t.test('errors on proto property', t => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-    const obj = JSON.parse(text)
 
-    t.throws(() => j.scan(obj), SyntaxError)
+    t.throws(() => j.parse(text), SyntaxError)
     t.end()
   })
+
+  t.test('errors on constructor property', t => {
+    const text = '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+
+    t.throws(() => j.parse(text), SyntaxError)
+    t.end()
+  })
+
 
   t.test('does not break when hasOwnProperty is overwritten', t => {
     const text = '{ "a": 5, "b": 6, "hasOwnProperty": "text", "__proto__": { "x": 7 } }'
-    const obj = JSON.parse(text)
 
-    j.scan(obj, { protoAction: 'remove' })
+    const obj = j.parse(text, { protoAction: 'remove' })
     t.deepEqual(obj, { a: 5, b: 6, hasOwnProperty: 'text' })
     t.end()
   })
-
   t.end()
 })
 
 test('safeParse', t => {
+  t.test('parses buffer', t => {
+    t.strictEqual(
+      j.safeParse(Buffer.from('"X"')),
+      JSON.parse(Buffer.from('"X"'))
+    )
+    t.end()
+  })
+
+  t.test('sanitizes nested object string', t => {
+    const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+
+    t.same(j.safeParse(text), null)
+    t.end()
+  })
+
+  t.test('returns null on constructor property', t => {
+    const text = '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+
+    t.same(j.safeParse(text), null)
+    t.end()
+  })
+
+  t.test('returns null on proto property', t => {
+    const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+
+    t.same(j.safeParse(text), null)
+    t.end()
+  })
+
+  t.test('returns null on constructor property', t => {
+    const text = '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+
+    t.same(j.safeParse(text), null)
+    t.end()
+  })
+
   t.test('parses object string', t => {
     t.deepEqual(
       j.safeParse('{"a": 5, "b": 6}'),
@@ -382,6 +425,22 @@ test('safeParse', t => {
     t.end()
   })
 
+  t.test('sanitizes object string (options)', t => {
+    t.deepEqual(
+      j.safeParse('{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }'),
+      null
+    )
+    t.end()
+  })
+
+  t.test('sanitizes object string (no prototype key)', t => {
+    t.deepEqual(
+      j.safeParse('{"a": 5, "b": 6,"constructor":{"bar":"baz"} }'),
+      { a: 5, b: 6, constructor: { bar: 'baz' } }
+    )
+    t.end()
+  })
+
   t.end()
 })
 
@@ -402,5 +461,25 @@ test('parse buffer with BOM', t => {
     Buffer.from(JSON.stringify(theJson))
   ])
   t.deepEqual(j.parse(buffer), theJson)
+  t.end()
+})
+
+test('safeParse string with BOM', t => {
+  const theJson = { hello: 'world' }
+  const buffer = Buffer.concat([
+    Buffer.from([239, 187, 191]), // the utf8 BOM
+    Buffer.from(JSON.stringify(theJson))
+  ])
+  t.deepEqual(j.safeParse(buffer.toString()), theJson)
+  t.end()
+})
+
+test('safeParse buffer with BOM', t => {
+  const theJson = { hello: 'world' }
+  const buffer = Buffer.concat([
+    Buffer.from([239, 187, 191]), // the utf8 BOM
+    Buffer.from(JSON.stringify(theJson))
+  ])
+  t.deepEqual(j.safeParse(buffer), theJson)
   t.end()
 })


### PR DESCRIPTION
This PR improves the performance in case malicious payload is provided.

Breaking Change:
- Removed the scan-function

before:

```
node valid
JSON.parse x 1,684,201 ops/sec ±0.74% (90 runs sampled)
JSON.parse proto x 1,090,668 ops/sec ±1.10% (87 runs sampled)
secure-json-parse parse x 1,437,734 ops/sec ±0.97% (88 runs sampled)
secure-json-parse parse proto x 1,580,499 ops/sec ±0.96% (87 runs sampled)
secure-json-parse safeParse x 1,420,574 ops/sec ±0.88% (87 runs sampled)
secure-json-parse safeParse proto x 136,433 ops/sec ±0.78% (90 runs sampled)
JSON.parse reviver x 500,856 ops/sec ±0.58% (89 runs sampled)
Fastest is JSON.parse
```

after:
```
JSON.parse x 1,725,767 ops/sec ±0.75% (91 runs sampled)
JSON.parse proto x 1,089,860 ops/sec ±0.71% (90 runs sampled)
secure-json-parse parse x 1,454,987 ops/sec ±0.73% (93 runs sampled)
secure-json-parse parse proto x 1,570,482 ops/sec ±0.66% (89 runs sampled)
secure-json-parse safeParse x 1,491,839 ops/sec ±0.91% (92 runs sampled)
secure-json-parse safeParse proto x 993,249 ops/sec ±0.95% (87 runs sampled)
JSON.parse reviver x 501,228 ops/sec ±0.79% (92 runs sampled)
Fastest is JSON.parse
```