### PR TITLE
move tests to test folder, refactor tests to implicitly test scan()

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "scripts": {
     "benchmark": "cd benchmarks && npm install && npm run all",
     "lint": "standard",
-    "test": "nyc tape test.js",
-    "test:unit": "tape test.js",
+    "test": "nyc npm run test:unit && npm run test:typescript",
+    "test:unit": "tape test/*.test.js",
     "test:typescript": "tsd",
-    "test:browser": "airtap test.js"
+    "test:browser": "airtap test/*.test.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "benchmark": "cd benchmarks && npm install && npm run all",
     "lint": "standard",
     "test": "nyc npm run test:unit && npm run test:typescript",
-    "test:unit": "tape test/*.test.js",
+    "test:unit": "tape \"test/*.test.js\"",
     "test:typescript": "tsd",
     "test:browser": "airtap test/*.test.js"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('tape').test
-const j = require('./index')
+const j = require('..')
 
 test('parse', t => {
   t.test('parses object string', t => {
@@ -324,40 +324,82 @@ test('parse', t => {
     t.end()
   })
 
-  t.end()
-})
-
-test('scan', t => {
   t.test('sanitizes nested object string', t => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-    const obj = JSON.parse(text)
 
-    j.scan(obj, { protoAction: 'remove' })
+    const obj = j.parse(text, { protoAction: 'remove' })
     t.deepEqual(obj, { a: 5, b: 6, c: { d: 0, e: 'text', f: { g: 2 } } })
+    t.end()
+  })
+
+  t.test('errors on constructor property', t => {
+    const text = '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+
+    t.throws(() => j.parse(text), SyntaxError)
     t.end()
   })
 
   t.test('errors on proto property', t => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-    const obj = JSON.parse(text)
 
-    t.throws(() => j.scan(obj), SyntaxError)
+    t.throws(() => j.parse(text), SyntaxError)
+    t.end()
+  })
+
+  t.test('errors on constructor property', t => {
+    const text = '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+
+    t.throws(() => j.parse(text), SyntaxError)
     t.end()
   })
 
   t.test('does not break when hasOwnProperty is overwritten', t => {
     const text = '{ "a": 5, "b": 6, "hasOwnProperty": "text", "__proto__": { "x": 7 } }'
-    const obj = JSON.parse(text)
 
-    j.scan(obj, { protoAction: 'remove' })
+    const obj = j.parse(text, { protoAction: 'remove' })
     t.deepEqual(obj, { a: 5, b: 6, hasOwnProperty: 'text' })
     t.end()
   })
-
   t.end()
 })
 
 test('safeParse', t => {
+  t.test('parses buffer', t => {
+    t.strictEqual(
+      j.safeParse(Buffer.from('"X"')),
+      JSON.parse(Buffer.from('"X"'))
+    )
+    t.end()
+  })
+
+  t.test('sanitizes nested object string', t => {
+    const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+
+    t.same(j.safeParse(text), null)
+    t.end()
+  })
+
+  t.test('returns null on constructor property', t => {
+    const text = '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+
+    t.same(j.safeParse(text), null)
+    t.end()
+  })
+
+  t.test('returns null on proto property', t => {
+    const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+
+    t.same(j.safeParse(text), null)
+    t.end()
+  })
+
+  t.test('returns null on constructor property', t => {
+    const text = '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+
+    t.same(j.safeParse(text), null)
+    t.end()
+  })
+
   t.test('parses object string', t => {
     t.deepEqual(
       j.safeParse('{"a": 5, "b": 6}'),
@@ -382,6 +424,22 @@ test('safeParse', t => {
     t.end()
   })
 
+  t.test('sanitizes object string (options)', t => {
+    t.deepEqual(
+      j.safeParse('{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }'),
+      null
+    )
+    t.end()
+  })
+
+  t.test('sanitizes object string (no prototype key)', t => {
+    t.deepEqual(
+      j.safeParse('{"a": 5, "b": 6,"constructor":{"bar":"baz"} }'),
+      { a: 5, b: 6, constructor: { bar: 'baz' } }
+    )
+    t.end()
+  })
+
   t.end()
 })
 
@@ -402,5 +460,30 @@ test('parse buffer with BOM', t => {
     Buffer.from(JSON.stringify(theJson))
   ])
   t.deepEqual(j.parse(buffer), theJson)
+  t.end()
+})
+
+test('safeParse string with BOM', t => {
+  const theJson = { hello: 'world' }
+  const buffer = Buffer.concat([
+    Buffer.from([239, 187, 191]), // the utf8 BOM
+    Buffer.from(JSON.stringify(theJson))
+  ])
+  t.deepEqual(j.safeParse(buffer.toString()), theJson)
+  t.end()
+})
+
+test('safeParse buffer with BOM', t => {
+  const theJson = { hello: 'world' }
+  const buffer = Buffer.concat([
+    Buffer.from([239, 187, 191]), // the utf8 BOM
+    Buffer.from(JSON.stringify(theJson))
+  ])
+  t.deepEqual(j.safeParse(buffer), theJson)
+  t.end()
+})
+
+test('scan handles optional options', t => {
+  t.doesNotThrow(() => j.scan({ a: 'b' }))
   t.end()
 })


### PR DESCRIPTION
This PR modifies the tests so that they implicitly test for scan(). This is useful, if we decide to drop exporting scan() in a major release.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
