### PR TITLE
improve performance of safeParse

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ function parse (text, reviver, options) {
     return obj
   }
 
-  const protoAction = options && options.protoAction || 'error'
-  const constructorAction = options && options.constructorAction || 'error'
+  const protoAction = (options && options.protoAction) || 'error'
+  const constructorAction = (options && options.constructorAction) || 'error'
 
   // options: 'error' (default) / 'remove' / 'ignore'
   if (protoAction === 'ignore' && constructorAction === 'ignore') {

--- a/index.js
+++ b/index.js
@@ -55,12 +55,10 @@ function parse (text, reviver, options) {
   }
 
   // Scan result for proto keys
-  scan(obj, { protoAction, constructorAction })
-
-  return obj
+  return filter(obj, { protoAction, constructorAction })
 }
 
-function scan (obj, { protoAction = 'error', constructorAction = 'error' } = {}) {
+function filter (obj, { protoAction = 'error', constructorAction = 'error' } = {}) {
   let next = [obj]
 
   while (next.length) {
@@ -94,11 +92,12 @@ function scan (obj, { protoAction = 'error', constructorAction = 'error' } = {})
       }
     }
   }
+  return obj
 }
 
-function safeParse (text, reviver) {
+function safeParse (text, reviver, options) {
   try {
-    return parse(text, reviver)
+    return parse(text, reviver, options)
   } catch (ignoreError) {
     return null
   }
@@ -106,6 +105,6 @@ function safeParse (text, reviver) {
 
 module.exports = {
   parse,
-  scan,
+  scan: filter,
   safeParse
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,30 +5,17 @@ export type ParseOptions = {
     * - `'remove'` - deletes any `__proto__` keys from the result object.
     * - `'ignore'` - skips all validation (same as calling `JSON.parse()` directly).
     */
-  protoAction?: 'error' | 'remove' | 'ignore',
+  protoAction?: 'error' | 'remove' | 'ignore';
   /**
    * What to do when a `constructor` key is found.
    * - `'error'` - throw a `SyntaxError` when a `constructor.prototype` key is found. This is the default value.
    * - `'remove'` - deletes any `constructor` keys from the result object.
    * - `'ignore'` - skips all validation (same as calling `JSON.parse()` directly).
    */
-  constructorAction?: 'error' | 'remove' | 'ignore',
+  constructorAction?: 'error' | 'remove' | 'ignore';
 }
 
-export type ScanOptions = {
-  /**
-   * What to do when a `__proto__` key is found.
-    * - `'error'` - throw a `SyntaxError` when a `__proto__` key is found. This is the default value.
-    * - `'remove'` - deletes any `__proto__` keys from the input `obj`.
-    */
-  protoAction?: 'error' | 'remove',
-  /**
-   * What to do when a `constructor` key is found.
-   * - `'error'` - throw a `SyntaxError` when a `constructor.prototype` key is found. This is the default value.
-   * - `'remove'` - deletes any `constructor` keys from the input `obj`.
-   */
-  constructorAction?: 'error' | 'remove',
-}
+export type ScanOptions = ParseOptions
 
 type Reviver = (this: any, key: string, value: any) => any
 
@@ -56,5 +43,6 @@ export function safeParse(text: string | Buffer, reviver?: Reviver | null): any
  *
  * @param obj The object being scanned.
  * @param options Optional configuration object.
+ * @returns The object, or `null` if onError is set to `nullify`
  */
-export function scan(obj: any, options?: ScanOptions): void
+export function scan(obj: {[key: string]: any }, options?: ParseOptions): any

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -45,4 +45,4 @@ export function safeParse(text: string | Buffer, reviver?: Reviver | null): any
  * @param options Optional configuration object.
  * @returns The object, or `null` if onError is set to `nullify`
  */
-export function scan(obj: {[key: string]: any }, options?: ParseOptions): any
+export function scan(obj: {[key: string | number]: any }, options?: ParseOptions): any

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -17,6 +17,7 @@ sjson.scan({}, { protoAction: 'remove' })
 sjson.scan({}, { protoAction: 'ignore' })
 sjson.scan({}, { constructorAction: 'error' })
 sjson.scan({}, { constructorAction: 'ignore' })
+sjson.scan(new Array(), {})
 
 declare const input: Buffer
 sjson.parse(input)

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -13,10 +13,10 @@ sjson.safeParse('"test"', null)
 sjson.safeParse('"test"')
 expectError(sjson.safeParse(null))
 
-sjson.scan('"test"', { protoAction: 'remove' })
-expectError(sjson.scan('"test"', { protoAction: 'ignore' }))
-sjson.scan('"test"', { constructorAction: 'error' })
-expectError(sjson.scan('"test"', { constructorAction: 'ignore' }))
+sjson.scan({}, { protoAction: 'remove' })
+sjson.scan({}, { protoAction: 'ignore' })
+sjson.scan({}, { constructorAction: 'error' })
+sjson.scan({}, { constructorAction: 'ignore' })
 
 declare const input: Buffer
 sjson.parse(input)


### PR DESCRIPTION
before:
JSON.parse x 1,711,391 ops/sec ±0.86% (87 runs sampled)
JSON.parse proto x 1,077,100 ops/sec ±1.18% (90 runs sampled)
secure-json-parse parse x 1,430,832 ops/sec ±1.00% (91 runs sampled)
secure-json-parse parse proto x 1,576,912 ops/sec ±1.14% (84 runs sampled)
secure-json-parse safeParse x 1,420,410 ops/sec ±1.06% (87 runs sampled)
secure-json-parse safeParse proto x 139,151 ops/sec ±0.97% (90 runs sampled)
JSON.parse reviver x 497,298 ops/sec ±0.83% (90 runs sampled)

after:
JSON.parse x 1,738,271 ops/sec ±0.84% (88 runs sampled)
JSON.parse proto x 1,100,147 ops/sec ±1.23% (89 runs sampled)
secure-json-parse parse x 1,441,809 ops/sec ±0.79% (91 runs sampled)
secure-json-parse parse proto x 1,592,567 ops/sec ±0.82% (82 runs sampled)
secure-json-parse safeParse x 1,405,980 ops/sec ±1.30% (90 runs sampled)
secure-json-parse safeParse proto x 917,157 ops/sec ±0.81% (92 runs sampled)
JSON.parse reviver x 501,752 ops/sec ±0.78% (88 runs sampled)


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
