### PR TITLE
improve performance on SyntaxErrors

### DIFF
--- a/benchmarks/throw.js
+++ b/benchmarks/throw.js
@@ -11,7 +11,7 @@ const internals = {
 const suite = new Benchmark.Suite()
 
 suite
-  .add('JSON.parse', () => {
+  .add('JSON.parse valid', () => {
     JSON.parse(internals.text)
   })
   .add('JSON.parse error', () => {
@@ -21,15 +21,15 @@ suite
   })
   .add('secure-json-parse parse', () => {
     try {
-      sjson.parse(internals.text)
+      sjson.parse(internals.invalid)
     } catch (ignoreErr) { }
   })
   .add('secure-json-parse safeParse', () => {
-    sjson.safeParse(internals.text)
+    sjson.safeParse(internals.invalid)
   })
   .add('reviver', () => {
     try {
-      JSON.parse(internals.text, internals.reviver)
+      JSON.parse(internals.invalid, internals.reviver)
     } catch (ignoreErr) { }
   })
   .on('cycle', (event) => {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const hasBuffer = typeof Buffer !== 'undefined'
 const suspectProtoRx = /"(?:_|\\u005[Ff])(?:_|\\u005[Ff])(?:p|\\u0070)(?:r|\\u0072)(?:o|\\u006[Ff])(?:t|\\u0074)(?:o|\\u006[Ff])(?:_|\\u005[Ff])(?:_|\\u005[Ff])"\s*:/
 const suspectConstructorRx = /"(?:c|\\u0063)(?:o|\\u006[Ff])(?:n|\\u006[Ee])(?:s|\\u0073)(?:t|\\u0074)(?:r|\\u0072)(?:u|\\u0075)(?:c|\\u0063)(?:t|\\u0074)(?:o|\\u006[Ff])(?:r|\\u0072)"\s*:/
 
-function parse (text, reviver, options) {
+function _parse (text, reviver, options) {
   // Normalize arguments
   if (options == null) {
     if (reviver !== null && typeof reviver === 'object') {
@@ -97,9 +97,19 @@ function filter (obj, { protoAction = 'error', constructorAction = 'error', safe
   return obj
 }
 
+function parse (text, reviver, options) {
+  Error.stackTraceLimit = 0
+  const result = _parse(text, reviver, options)
+  Error.stackTraceLimit = 10
+  return result
+}
+
 function safeParse (text, reviver) {
   try {
-    return parse(text, reviver, { safe: true })
+    Error.stackTraceLimit = 0
+    const result = _parse(text, reviver, { safe: true })
+    Error.stackTraceLimit = 10
+    return result
   } catch (ignoreError) {
     return null
   }


### PR DESCRIPTION
I investigated the performance of secure-json-parse and I think I found a potential peformance optimization. But I am unsure how useful it is in regard  of fastify.

I optimized few months ago secure-json-parse safeParse method, but I didnt apply it to fastify, because Errors are needed to give useful feedback. So we didnt have any benefit from the performance chances back then. 

So I realized, that the stackTrace is one of the reasons, we have performance degredation. So in a naive attempt I propose this patch. I mean... it is not nice to set Error.stackTraceLimit to 0 and then back to 10 every time we parse JSON. Can there be some kind of race condition? idk. 

But here I propose a solution, which improves the performance of secure-json-parse in case a malicious attacker sends invalid payloads. 

before:
```sh
node benchmarks/valid.js
JSON.parse x 1,571,384 ops/sec ±0.24% (95 runs sampled)
JSON.parse proto x 1,048,214 ops/sec ±1.14% (88 runs sampled)
secure-json-parse parse x 1,430,655 ops/sec ±1.03% (91 runs sampled)
secure-json-parse parse proto x 1,589,677 ops/sec ±1.20% (93 runs sampled)
secure-json-parse safeParse x 1,333,056 ops/sec ±0.70% (87 runs sampled)
secure-json-parse safeParse proto x 930,279 ops/sec ±1.02% (93 runs sampled)
JSON.parse reviver x 495,446 ops/sec ±0.92% (92 runs sampled)
Fastest is secure-json-parse parse proto,JSON.parse

JSON.parse valid x 1,052,749 ops/sec ±1.26% (91 runs sampled)
JSON.parse error x 158,899 ops/sec ±1.96% (81 runs sampled)
secure-json-parse parse x 146,439 ops/sec ±1.34% (89 runs sampled)
secure-json-parse safeParse x 146,369 ops/sec ±1.02% (83 runs sampled)
reviver x 172,568 ops/sec ±1.45% (92 runs sampled)
Fastest is JSON.parse valid
```

after:
```sh
node benchmarks/valid.js
JSON.parse x 1,757,461 ops/sec ±1.06% (93 runs sampled)
JSON.parse proto x 1,151,909 ops/sec ±0.08% (99 runs sampled)
secure-json-parse parse x 1,536,503 ops/sec ±0.12% (96 runs sampled)
secure-json-parse parse proto x 1,594,364 ops/sec ±1.24% (93 runs sampled)
secure-json-parse safeParse x 1,456,892 ops/sec ±0.89% (92 runs sampled)
secure-json-parse safeParse proto x 972,132 ops/sec ±1.04% (88 runs sampled)
JSON.parse reviver x 483,890 ops/sec ±0.41% (94 runs sampled)
Fastest is JSON.parse

 node benchmarks/throw.js
JSON.parse valid x 1,096,431 ops/sec ±1.24% (93 runs sampled)
JSON.parse error x 150,274 ops/sec ±0.19% (91 runs sampled)
secure-json-parse parse x 361,685 ops/sec ±0.91% (97 runs sampled)
secure-json-parse safeParse x 390,507 ops/sec ±0.12% (96 runs sampled)
reviver x 491,551 ops/sec ±0.12% (93 runs sampled)
Fastest is JSON.parse valid

```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
