### PR TITLE
fix(index): return `undefined` on error instead of `null`

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function safeParse (text, reviver) {
   try {
     return _parse(text, reviver, { safe: true })
   } catch (_e) {
-    return null
+    return undefined
   } finally {
     Error.stackTraceLimit = stackTraceLimit
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -432,10 +432,10 @@ test('safeParse', t => {
     t.end()
   })
 
-  t.test('returns null on invalid object string', t => {
+  t.test('returns undefined on invalid object string', t => {
     t.strictEqual(
       j.safeParse('{"a": 5, "b": 6'),
-      null
+      undefined
     )
     t.end()
   })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -37,7 +37,7 @@ declare namespace parse {
    *
    * @param text The JSON text string.
    * @param reviver The `JSON.parse()` optional `reviver` argument.
-   * @returns The parsed object, or `null` if there was an error or if the JSON contained possibly insecure properties.
+   * @returns The parsed object, or `undefined` if there was an error or if the JSON contained possibly insecure properties.
    */
   export function safeParse (text: string | Buffer, reviver?: Reviver | null): any
 


### PR DESCRIPTION
closes #132 

This is a breaking change so it'd be great to combine this with https://github.com/fastify/secure-json-parse/issues/72

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
