### PR TITLE
ci(.github): use latest node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
+          check-latest: true
           node-version: lts/*
 
       - name: Install dependencies
@@ -66,6 +67,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
+          check-latest: true
           node-version: lts/*
 
       - name: Install dependencies
@@ -94,6 +96,7 @@ jobs:
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
+          check-latest: true
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
@@ -116,6 +119,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
+          check-latest: true
           node-version: lts/*
 
       - name: Install dependencies


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5577. This is a batch PR, so may have some issues. Please review changes.