### PR TITLE
refactor: migrate tests from tape to node:test

### DIFF
--- a/.airtap.yml
+++ b/.airtap.yml
@@ -1,7 +1,0 @@
-providers:
-  - airtap-playwright
-
-browsers:
-  - name: chromium
-    supports:
-      headless: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,32 @@ jobs:
       license-check: true
       lint: true
 
+  browsers:
+    name: Test Browsers
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          check-latest: true
+          node-version: lts/*
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Install Playwright
+        run: npx playwright install
+
+      - name: Run tests
+        run: npm run test:browser
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -87,7 +113,7 @@ jobs:
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.pull_request.user.login == 'dependabot[bot]'
-    needs: [quality-check, test, typescript]
+    needs: [browsers, quality-check, test, typescript]
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,32 +32,6 @@ jobs:
       license-check: true
       lint: true
 
-  browsers:
-    name: Test Browsers
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          check-latest: true
-          node-version: lts/*
-
-      - name: Install dependencies
-        run: npm i
-
-      - name: Install Playwright
-        run: npx playwright install
-
-      - name: Run tests
-        run: npm run test:browser
-
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -113,7 +87,7 @@ jobs:
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.pull_request.user.login == 'dependabot[bot]'
-    needs: [browsers, quality-check, test, typescript]
+    needs: [quality-check, test, typescript]
     permissions:
       pull-requests: write
       contents: write

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "nyc npm run test:unit && npm run test:typescript",
     "test:unit": "node --test test/*.test.js",
     "test:typescript": "tstyche",
-    "test:browser": "node --test test/*.test.js"
+    "test:browser": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -66,7 +66,7 @@
     "eslint": "^9.17.0",
     "neostandard": "^0.13.0",
     "nyc": "^18.0.0",
-    "playwright": "^1.43.1",
+    "playwright": "^1.60.0",
     "tstyche": "^7.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,8 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "test": "nyc npm run test:unit && npm run test:typescript",
-    "test:unit": "tape \"test/*.test.js\"",
-    "test:typescript": "tstyche",
-    "test:browser": "airtap test/*.test.js"
+    "test:unit": "node --test test/*.test.js",
+    "test:typescript": "tstyche"
   },
   "repository": {
     "type": "git",
@@ -62,13 +61,10 @@
     }
   ],
   "devDependencies": {
-    "airtap": "^5.0.0",
-    "airtap-playwright": "^1.0.1",
+    "@types/node": "^25.9.1",
     "eslint": "^9.17.0",
     "neostandard": "^0.13.0",
     "nyc": "^18.0.0",
-    "playwright": "^1.43.1",
-    "tape": "^5.7.5",
     "tstyche": "^7.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:fix": "eslint --fix",
     "test": "nyc npm run test:unit && npm run test:typescript",
     "test:unit": "node --test test/*.test.js",
-    "test:typescript": "tstyche"
+    "test:typescript": "tstyche",
+    "test:browser": "node --test test/*.test.js"
   },
   "repository": {
     "type": "git",
@@ -65,6 +66,7 @@
     "eslint": "^9.17.0",
     "neostandard": "^0.13.0",
     "nyc": "^18.0.0",
+    "playwright": "^1.43.1",
     "tstyche": "^7.1.0"
   }
 }

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const { test } = require('playwright/test')
+const fs = require('node:fs')
+const path = require('node:path')
+
+test('should run safely in the browser without Buffer crashing', async ({ page }) => {
+  const libCode = fs.readFileSync(path.join(__dirname, '../index.js'), 'utf8')
+
+  await page.evaluate((src) => {
+    const module = { exports: {} }
+    // eslint-disable-next-line no-new-func
+    new Function('module', 'exports', src)(module, module.exports)
+    const parse = module.exports
+
+    if (typeof Buffer !== 'undefined') {
+      throw new Error('Buffer is leaking inside the browser environment!')
+    }
+
+    // eslint-disable-next-line no-proto
+    const res = parse('{"a":1,"__proto__":{"b":2}}', null, { protoAction: 'remove' })
+
+    // eslint-disable-next-line no-proto
+    if (res.a !== 1 || (res.__proto__ && res.__proto__.b === 2)) {
+      throw new Error('Prototype pollution protection logic is broken client-side!')
+    }
+  }, libCode)
+})

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -17,7 +17,6 @@ test('should run safely in the browser without Buffer crashing', async ({ page }
       throw new Error('Buffer is leaking inside the browser environment!')
     }
 
-    // eslint-disable-next-line no-proto
     const res = parse('{"a":1,"__proto__":{"b":2}}', null, { protoAction: 'remove' })
 
     // eslint-disable-next-line no-proto

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,649 +1,534 @@
 'use strict'
 
-const { test } = require('tape')
+const { test } = require('node:test')
+const assert = require('node:assert')
 const j = require('..')
 
-test('parse', t => {
-  t.test('parses object string', t => {
-    t.deepEqual(
+test('parse', async (t) => {
+  await t.test('parses object string', () => {
+    assert.deepEqual(
       j.parse('{"a": 5, "b": 6}'),
       JSON.parse('{"a": 5, "b": 6}')
     )
-    t.end()
   })
 
-  t.test('parses null string', t => {
-    t.strictEqual(
-      j.parse('null'),
-      JSON.parse('null')
-    )
-    t.end()
+  await t.test('parses null string', () => {
+    assert.strictEqual(j.parse('null'), JSON.parse('null'))
   })
 
-  t.test('parses 0 string', t => {
-    t.strictEqual(
-      j.parse('0'),
-      JSON.parse('0')
-    )
-    t.end()
+  await t.test('parses 0 string', () => {
+    assert.strictEqual(j.parse('0'), JSON.parse('0'))
   })
 
-  t.test('parses string string', t => {
-    t.strictEqual(
-      j.parse('"X"'),
-      JSON.parse('"X"')
-    )
-    t.end()
+  await t.test('parses string string', () => {
+    assert.strictEqual(j.parse('"X"'), JSON.parse('"X"'))
   })
 
-  t.test('parses buffer', t => {
-    t.strictEqual(
+  await t.test('parses buffer', () => {
+    assert.strictEqual(
       j.parse(Buffer.from('"X"')),
       JSON.parse(Buffer.from('"X"'))
     )
-    t.end()
   })
 
-  t.test('parses object string (reviver)', t => {
+  await t.test('parses object string (reviver)', () => {
     const reviver = (_key, value) => {
       return typeof value === 'number' ? value + 1 : value
     }
 
-    t.deepEqual(
+    assert.deepEqual(
       j.parse('{"a": 5, "b": 6}', reviver),
       JSON.parse('{"a": 5, "b": 6}', reviver)
     )
-    t.end()
   })
 
-  t.test('protoAction', t => {
-    t.test('sanitizes object string (reviver, options)', t => {
+  await t.test('protoAction', async (t) => {
+    await t.test('sanitizes object string (reviver, options)', () => {
       const reviver = (_key, value) => {
         return typeof value === 'number' ? value + 1 : value
       }
 
-      t.deepEqual(
+      assert.deepEqual(
         j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', reviver, { protoAction: 'remove' }),
         { a: 6, b: 7 }
       )
-      t.end()
     })
 
-    t.test('sanitizes object string (options)', t => {
-      t.deepEqual(
+    await t.test('sanitizes object string (options)', () => {
+      assert.deepEqual(
         j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', { protoAction: 'remove' }),
         { a: 5, b: 6 }
       )
-      t.end()
     })
 
-    t.test('sanitizes object string (null, options)', t => {
-      t.deepEqual(
+    await t.test('sanitizes object string (null, options)', () => {
+      assert.deepEqual(
         j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', null, { protoAction: 'remove' }),
         { a: 5, b: 6 }
       )
-      t.end()
     })
 
-    t.test('sanitizes object string (null, options)', t => {
-      t.deepEqual(
+    await t.test('sanitizes object string (null, options)', () => {
+      assert.deepEqual(
         j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', { protoAction: 'remove' }),
         { a: 5, b: 6 }
       )
-      t.end()
     })
 
-    t.test('sanitizes nested object string', t => {
-      t.deepEqual(
+    await t.test('sanitizes nested object string', () => {
+      assert.deepEqual(
         j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }', { protoAction: 'remove' }),
         { a: 5, b: 6, c: { d: 0, e: 'text', f: { g: 2 } } }
       )
-      t.end()
     })
 
-    t.test('ignores proto property', t => {
-      t.deepEqual(
+    await t.test('ignores proto property', () => {
+      assert.deepEqual(
         j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }', { protoAction: 'ignore' }),
         JSON.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }')
       )
-      t.end()
     })
 
-    t.test('ignores proto value', t => {
-      t.deepEqual(
+    await t.test('ignores proto value', () => {
+      assert.deepEqual(
         j.parse('{"a": 5, "b": "__proto__"}'),
         { a: 5, b: '__proto__' }
       )
-      t.end()
     })
 
-    t.test('errors on proto property', t => {
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'), SyntaxError)
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__" : { "x": 7 } }'), SyntaxError)
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__" \n\r\t : { "x": 7 } }'), SyntaxError)
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__" \n \r \t : { "x": 7 } }'), SyntaxError)
-      t.end()
+    await t.test('errors on proto property', () => {
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'), SyntaxError)
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__" : { "x": 7 } }'), SyntaxError)
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__" \n\r\t : { "x": 7 } }'), SyntaxError)
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__" \n \r \t : { "x": 7 } }'), SyntaxError)
     })
 
-    t.test('errors on proto property (null, null)', t => {
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }', null, null), SyntaxError)
-      t.end()
+    await t.test('errors on proto property (null, null)', () => {
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }', null, null), SyntaxError)
     })
 
-    t.test('errors on proto property (explicit options)', t => {
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }', { protoAction: 'error' }), SyntaxError)
-      t.end()
+    await t.test('errors on proto property (explicit options)', () => {
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }', { protoAction: 'error' }), SyntaxError)
     })
 
-    t.test('errors on proto property (unicode)', t => {
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005f_proto__": { "x": 7 } }'), SyntaxError)
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "_\\u005fp\\u0072oto__": { "x": 7 } }'), SyntaxError)
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005f\\u005f\\u0070\\u0072\\u006f\\u0074\\u006f\\u005f\\u005f": { "x": 7 } }'), SyntaxError)
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005F_proto__": { "x": 7 } }'), SyntaxError)
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "_\\u005Fp\\u0072oto__": { "x": 7 } }'), SyntaxError)
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005F\\u005F\\u0070\\u0072\\u006F\\u0074\\u006F\\u005F\\u005F": { "x": 7 } }'), SyntaxError)
-      t.end()
+    await t.test('errors on proto property (unicode)', () => {
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005f_proto__": { "x": 7 } }'), SyntaxError)
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "_\\u005fp\\u0072oto__": { "x": 7 } }'), SyntaxError)
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005f\\u005f\\u0070\\u0072\\u006f\\u0074\\u006f\\u005f\\u005f": { "x": 7 } }'), SyntaxError)
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005F_proto__": { "x": 7 } }'), SyntaxError)
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "_\\u005Fp\\u0072oto__": { "x": 7 } }'), SyntaxError)
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005F\\u005F\\u0070\\u0072\\u006F\\u0074\\u006F\\u005F\\u005F": { "x": 7 } }'), SyntaxError)
     })
 
-    t.test('should reset stackTraceLimit', t => {
+    await t.test('should reset stackTraceLimit', () => {
       const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
       Error.stackTraceLimit = 42
-      t.throws(() => j.parse(text))
-      t.same(Error.stackTraceLimit, 42)
-      t.end()
+      assert.throws(() => j.parse(text))
+      assert.strictEqual(Error.stackTraceLimit, 42)
     })
-
-    t.end()
   })
 
-  t.test('constructorAction', t => {
-    t.test('sanitizes object string (reviver, options)', t => {
+  await t.test('constructorAction', async (t) => {
+    await t.test('sanitizes object string (reviver, options)', () => {
       const reviver = (_key, value) => {
         return typeof value === 'number' ? value + 1 : value
       }
 
-      t.deepEqual(
+      assert.deepEqual(
         j.parse('{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }', reviver, { constructorAction: 'remove' }),
         { a: 6, b: 7 }
       )
-      t.end()
     })
 
-    t.test('sanitizes object string (options)', t => {
-      t.deepEqual(
+    await t.test('sanitizes object string (options)', () => {
+      assert.deepEqual(
         j.parse('{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }', { constructorAction: 'remove' }),
         { a: 5, b: 6 }
       )
-      t.end()
     })
 
-    t.test('sanitizes object string (null, options)', t => {
-      t.deepEqual(
+    await t.test('sanitizes object string (null, options)', () => {
+      assert.deepEqual(
         j.parse('{"a": 5, "b": 6,"constructor":{"prototype":{"bar":"baz"}} }', null, { constructorAction: 'remove' }),
         { a: 5, b: 6 }
       )
-      t.end()
     })
 
-    t.test('sanitizes object string (null, options)', t => {
-      t.deepEqual(
+    await t.test('sanitizes object string (null, options)', () => {
+      assert.deepEqual(
         j.parse('{"a": 5, "b": 6,"constructor":{"prototype":{"bar":"baz"}} }', { constructorAction: 'remove' }),
         { a: 5, b: 6 }
       )
-      t.end()
     })
 
-    t.test('sanitizes object string (no prototype key)', t => {
-      t.deepEqual(
+    await t.test('sanitizes object string (no prototype key)', () => {
+      assert.deepEqual(
         j.parse('{"a": 5, "b": 6,"constructor":{"bar":"baz"} }', { constructorAction: 'remove' }),
         { a: 5, b: 6, constructor: { bar: 'baz' } }
       )
-      t.end()
     })
 
-    t.test('sanitizes nested object string', t => {
-      t.deepEqual(
+    await t.test('sanitizes nested object string', () => {
+      assert.deepEqual(
         j.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "c": { "d": 0, "e": "text", "constructor":{"prototype":{"bar":"baz"}}, "f": { "g": 2 } } }', { constructorAction: 'remove' }),
         { a: 5, b: 6, c: { d: 0, e: 'text', f: { g: 2 } } }
       )
-      t.end()
     })
 
-    t.test('ignores proto property', t => {
-      t.deepEqual(
+    await t.test('ignores proto property', () => {
+      assert.deepEqual(
         j.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }', { constructorAction: 'ignore' }),
         JSON.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }')
       )
-      t.end()
     })
 
-    t.test('ignores proto value', t => {
-      t.deepEqual(
+    await t.test('ignores proto value', () => {
+      assert.deepEqual(
         j.parse('{"a": 5, "b": "constructor"}'),
         { a: 5, b: 'constructor' }
       )
-      t.end()
     })
 
-    t.test('errors on proto property', t => {
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "constructor": {"prototype":{"bar":"baz"}} }'), SyntaxError)
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "constructor" : {"prototype":{"bar":"baz"}} }'), SyntaxError)
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "constructor" \n\r\t : {"prototype":{"bar":"baz"}} }'), SyntaxError)
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "constructor" \n \r \t : {"prototype":{"bar":"baz"}} }'), SyntaxError)
-      t.end()
+    await t.test('errors on proto property', () => {
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "constructor": {"prototype":{"bar":"baz"}} }'), SyntaxError)
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "constructor" : {"prototype":{"bar":"baz"}} }'), SyntaxError)
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "constructor" \n\r\t : {"prototype":{"bar":"baz"}} }'), SyntaxError)
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "constructor" \n \r \t : {"prototype":{"bar":"baz"}} }'), SyntaxError)
     })
 
-    t.test('Should not throw if the constructor key hasn\'t a child named prototype', t => {
-      t.doesNotThrow(() => j.parse('{ "a": 5, "b": 6, "constructor":{"bar":"baz"} }', null, null), SyntaxError)
-      t.end()
+    await t.test("should not throw if the constructor key hasn't a child named prototype", () => {
+      assert.doesNotThrow(() => j.parse('{ "a": 5, "b": 6, "constructor":{"bar":"baz"} }', null, null), SyntaxError)
     })
 
-    t.test('errors on proto property (null, null)', t => {
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }', null, null), SyntaxError)
-      t.end()
+    await t.test('errors on proto property (null, null)', () => {
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }', null, null), SyntaxError)
     })
 
-    t.test('errors on proto property (explicit options)', t => {
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }', { constructorAction: 'error' }), SyntaxError)
-      t.end()
+    await t.test('errors on proto property (explicit options)', () => {
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }', { constructorAction: 'error' }), SyntaxError)
     })
 
-    t.test('errors on proto property (unicode)', t => {
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006fnstructor": {"prototype":{"bar":"baz"}} }'), SyntaxError)
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006f\\u006e\\u0073\\u0074ructor": {"prototype":{"bar":"baz"}} }'), SyntaxError)
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006f\\u006e\\u0073\\u0074\\u0072\\u0075\\u0063\\u0074\\u006f\\u0072": {"prototype":{"bar":"baz"}} }'), SyntaxError)
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006Fnstructor": {"prototype":{"bar":"baz"}} }'), SyntaxError)
-      t.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006F\\u006E\\u0073\\u0074\\u0072\\u0075\\u0063\\u0074\\u006F\\u0072": {"prototype":{"bar":"baz"}} }'), SyntaxError)
-      t.end()
+    await t.test('errors on proto property (unicode)', () => {
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006fnstructor": {"prototype":{"bar":"baz"}} }'), SyntaxError)
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006f\\u006e\\u0073\\u0074ructor": {"prototype":{"bar":"baz"}} }'), SyntaxError)
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006f\\u006e\\u0073\\u0074\\u0072\\u0075\\u0063\\u0074\\u006f\\u0072": {"prototype":{"bar":"baz"}} }'), SyntaxError)
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006Fnstructor": {"prototype":{"bar":"baz"}} }'), SyntaxError)
+      assert.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006F\\u006E\\u0073\\u0074\\u0072\\u0075\\u0063\\u0074\\u006F\\u0072": {"prototype":{"bar":"baz"}} }'), SyntaxError)
     })
 
-    t.test('handles constructor null safely', t => {
-      // Test that constructor: null doesn't trigger prototype pollution checks
-      t.deepEqual(
+    await t.test('handles constructor null safely', () => {
+      assert.deepEqual(
         j.parse('{"constructor": null}', { constructorAction: 'remove' }),
         { constructor: null }
       )
 
-      // Test that constructor: null doesn't throw error when using error action
-      t.deepEqual(
+      assert.deepEqual(
         j.parse('{"constructor": null}', { constructorAction: 'error' }),
         { constructor: null }
       )
 
-      // Test that constructor: null is preserved when using ignore action
-      t.deepEqual(
+      assert.deepEqual(
         j.parse('{"constructor": null}', { constructorAction: 'ignore' }),
         { constructor: null }
       )
-      t.end()
     })
-
-    t.end()
   })
 
-  t.test('protoAction and constructorAction', t => {
-    t.test('protoAction=remove constructorAction=remove', t => {
-      t.deepEqual(
+  await t.test('protoAction and constructorAction', async (t) => {
+    await t.test('protoAction=remove constructorAction=remove', () => {
+      assert.deepEqual(
         j.parse(
           '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
           { protoAction: 'remove', constructorAction: 'remove' }
         ),
         { a: 5, b: 6 }
       )
-      t.end()
     })
 
-    t.test('protoAction=ignore constructorAction=remove', t => {
-      t.deepEqual(
+    await t.test('protoAction=ignore constructorAction=remove', () => {
+      assert.deepEqual(
         j.parse(
           '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
           { protoAction: 'ignore', constructorAction: 'remove' }
         ),
         JSON.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }')
       )
-      t.end()
     })
 
-    t.test('protoAction=remove constructorAction=ignore', t => {
-      t.deepEqual(
+    await t.test('protoAction=remove constructorAction=ignore', () => {
+      assert.deepEqual(
         j.parse(
           '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
           { protoAction: 'remove', constructorAction: 'ignore' }
         ),
         JSON.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }')
       )
-      t.end()
     })
 
-    t.test('protoAction=ignore constructorAction=ignore', t => {
-      t.deepEqual(
+    await t.test('protoAction=ignore constructorAction=ignore', () => {
+      assert.deepEqual(
         j.parse(
           '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
           { protoAction: 'ignore', constructorAction: 'ignore' }
         ),
         JSON.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }')
       )
-      t.end()
     })
 
-    t.test('protoAction=error constructorAction=ignore', t => {
-      t.throws(() => j.parse(
+    await t.test('protoAction=error constructorAction=ignore', () => {
+      assert.throws(() => j.parse(
         '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
         { protoAction: 'error', constructorAction: 'ignore' }
       ), SyntaxError)
-      t.end()
     })
 
-    t.test('protoAction=ignore constructorAction=error', t => {
-      t.throws(() => j.parse(
+    await t.test('protoAction=ignore constructorAction=error', () => {
+      assert.throws(() => j.parse(
         '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
         { protoAction: 'ignore', constructorAction: 'error' }
       ), SyntaxError)
-      t.end()
     })
 
-    t.test('protoAction=error constructorAction=error', t => {
-      t.throws(() => j.parse(
+    await t.test('protoAction=error constructorAction=error', () => {
+      assert.throws(() => j.parse(
         '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
         { protoAction: 'error', constructorAction: 'error' }
       ), SyntaxError)
-      t.end()
     })
-
-    t.end()
   })
 
-  t.test('sanitizes nested object string', t => {
+  await t.test('sanitizes nested object string', () => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-
     const obj = j.parse(text, { protoAction: 'remove' })
-    t.deepEqual(obj, { a: 5, b: 6, c: { d: 0, e: 'text', f: { g: 2 } } })
-    t.end()
+    assert.deepEqual(obj, { a: 5, b: 6, c: { d: 0, e: 'text', f: { g: 2 } } })
   })
 
-  t.test('errors on constructor property', t => {
+  await t.test('errors on constructor property', () => {
     const text = '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-
-    t.throws(() => j.parse(text), SyntaxError)
-    t.end()
+    assert.throws(() => j.parse(text), SyntaxError)
   })
 
-  t.test('errors on proto property', t => {
+  await t.test('errors on proto property', () => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-
-    t.throws(() => j.parse(text), SyntaxError)
-    t.end()
+    assert.throws(() => j.parse(text), SyntaxError)
   })
 
-  t.test('errors on constructor property', t => {
+  await t.test('errors on constructor property', () => {
     const text = '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-
-    t.throws(() => j.parse(text), SyntaxError)
-    t.end()
+    assert.throws(() => j.parse(text), SyntaxError)
   })
 
-  t.test('does not break when hasOwnProperty is overwritten', t => {
+  await t.test('does not break when hasOwnProperty is overwritten', () => {
     const text = '{ "a": 5, "b": 6, "hasOwnProperty": "text", "__proto__": { "x": 7 } }'
-
     const obj = j.parse(text, { protoAction: 'remove' })
-    t.deepEqual(obj, { a: 5, b: 6, hasOwnProperty: 'text' })
-    t.end()
+    assert.deepEqual(obj, { a: 5, b: 6, hasOwnProperty: 'text' })
   })
-  t.end()
 })
 
-test('safeParse', t => {
-  t.test('parses buffer', t => {
-    t.strictEqual(
+test('safeParse', async (t) => {
+  await t.test('parses buffer', () => {
+    assert.strictEqual(
       j.safeParse(Buffer.from('"X"')),
       JSON.parse(Buffer.from('"X"'))
     )
-    t.end()
   })
 
-  t.test('should reset stackTraceLimit', t => {
+  await t.test('should reset stackTraceLimit', () => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
     Error.stackTraceLimit = 42
-    t.same(j.safeParse(text), null)
-    t.same(Error.stackTraceLimit, 42)
-    t.end()
+    assert.strictEqual(j.safeParse(text), null)
+    assert.strictEqual(Error.stackTraceLimit, 42)
   })
 
-  t.test('sanitizes nested object string', t => {
+  await t.test('sanitizes nested object string', () => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-
-    t.same(j.safeParse(text), null)
-    t.end()
+    assert.strictEqual(j.safeParse(text), null)
   })
 
-  t.test('returns null on constructor property', t => {
+  await t.test('returns null on constructor property', () => {
     const text = '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-
-    t.same(j.safeParse(text), null)
-    t.end()
+    assert.strictEqual(j.safeParse(text), null)
   })
 
-  t.test('returns null on proto property', t => {
+  await t.test('returns null on proto property', () => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-
-    t.same(j.safeParse(text), null)
-    t.end()
+    assert.strictEqual(j.safeParse(text), null)
   })
 
-  t.test('returns null on constructor property', t => {
+  await t.test('returns null on constructor property', () => {
     const text = '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-
-    t.same(j.safeParse(text), null)
-    t.end()
+    assert.strictEqual(j.safeParse(text), null)
   })
 
-  t.test('parses object string', t => {
-    t.deepEqual(
-      j.safeParse('{"a": 5, "b": 6}'),
-      { a: 5, b: 6 }
-    )
-    t.end()
+  await t.test('parses object string', () => {
+    assert.deepEqual(j.safeParse('{"a": 5, "b": 6}'), { a: 5, b: 6 })
   })
 
-  t.test('returns null on proto object string', t => {
-    t.strictEqual(
+  await t.test('returns null on proto object string', () => {
+    assert.strictEqual(
       j.safeParse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'),
       null
     )
-    t.end()
   })
 
-  t.test('returns undefined on invalid object string', t => {
-    t.strictEqual(
-      j.safeParse('{"a": 5, "b": 6'),
-      undefined
-    )
-    t.end()
+  await t.test('returns undefined on invalid object string', () => {
+    assert.strictEqual(j.safeParse('{"a": 5, "b": 6'), undefined)
   })
 
-  t.test('sanitizes object string (options)', t => {
-    t.deepEqual(
+  await t.test('sanitizes object string (options)', () => {
+    assert.strictEqual(
       j.safeParse('{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }'),
       null
     )
-    t.end()
   })
 
-  t.test('sanitizes object string (no prototype key)', t => {
-    t.deepEqual(
+  await t.test('sanitizes object string (no prototype key)', () => {
+    assert.deepEqual(
       j.safeParse('{"a": 5, "b": 6,"constructor":{"bar":"baz"} }'),
       { a: 5, b: 6, constructor: { bar: 'baz' } }
     )
-    t.end()
   })
-
-  t.end()
 })
 
-test('parse string with BOM', t => {
+test('parse string with BOM', () => {
   const theJson = { hello: 'world' }
   const buffer = Buffer.concat([
     Buffer.from([239, 187, 191]), // the utf8 BOM
     Buffer.from(JSON.stringify(theJson))
   ])
-  t.deepEqual(j.parse(buffer.toString()), theJson)
-  t.end()
+  assert.deepEqual(j.parse(buffer.toString()), theJson)
 })
 
-test('parse buffer with BOM', t => {
+test('parse buffer with BOM', () => {
   const theJson = { hello: 'world' }
   const buffer = Buffer.concat([
     Buffer.from([239, 187, 191]), // the utf8 BOM
     Buffer.from(JSON.stringify(theJson))
   ])
-  t.deepEqual(j.parse(buffer), theJson)
-  t.end()
+  assert.deepEqual(j.parse(buffer), theJson)
 })
 
-test('safeParse string with BOM', t => {
+test('safeParse string with BOM', () => {
   const theJson = { hello: 'world' }
   const buffer = Buffer.concat([
     Buffer.from([239, 187, 191]), // the utf8 BOM
     Buffer.from(JSON.stringify(theJson))
   ])
-  t.deepEqual(j.safeParse(buffer.toString()), theJson)
-  t.end()
+  assert.deepEqual(j.safeParse(buffer.toString()), theJson)
 })
 
-test('safeParse buffer with BOM', t => {
+test('safeParse buffer with BOM', () => {
   const theJson = { hello: 'world' }
   const buffer = Buffer.concat([
     Buffer.from([239, 187, 191]), // the utf8 BOM
     Buffer.from(JSON.stringify(theJson))
   ])
-  t.deepEqual(j.safeParse(buffer), theJson)
-  t.end()
+  assert.deepEqual(j.safeParse(buffer), theJson)
 })
 
-test('scan handles optional options', t => {
-  t.doesNotThrow(() => j.scan({ a: 'b' }))
-  t.end()
+test('scan handles optional options', () => {
+  assert.doesNotThrow(() => j.scan({ a: 'b' }))
 })
 
-test('safe option', t => {
-  t.test('parse with safe=true returns null on __proto__', t => {
+test('safe option', async (t) => {
+  await t.test('parse with safe=true returns null on __proto__', () => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'
-    t.strictEqual(j.parse(text, { safe: true }), null)
-    t.end()
+    assert.strictEqual(j.parse(text, { safe: true }), null)
   })
 
-  t.test('parse with safe=true returns null on constructor', t => {
+  await t.test('parse with safe=true returns null on constructor', () => {
     const text = '{ "a": 5, "b": 6, "constructor": {"prototype": {"bar": "baz"}} }'
-    t.strictEqual(j.parse(text, { safe: true }), null)
-    t.end()
+    assert.strictEqual(j.parse(text, { safe: true }), null)
   })
 
-  t.test('parse with safe=true returns object when valid', t => {
+  await t.test('parse with safe=true returns object when valid', () => {
     const text = '{ "a": 5, "b": 6 }'
-    t.deepEqual(j.parse(text, { safe: true }), { a: 5, b: 6 })
-    t.end()
+    assert.deepEqual(j.parse(text, { safe: true }), { a: 5, b: 6 })
   })
 
-  t.test('parse with safe=true and reviver', t => {
+  await t.test('parse with safe=true and reviver', () => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'
     const reviver = (_key, value) => {
       return typeof value === 'number' ? value + 1 : value
     }
-    t.strictEqual(j.parse(text, reviver, { safe: true }), null)
-    t.end()
+    assert.strictEqual(j.parse(text, reviver, { safe: true }), null)
   })
 
-  t.test('parse with safe=true and protoAction=remove returns null', t => {
+  await t.test('parse with safe=true and protoAction=remove returns null', () => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'
-    t.strictEqual(j.parse(text, { safe: true, protoAction: 'remove' }), null)
-    t.end()
+    assert.strictEqual(j.parse(text, { safe: true, protoAction: 'remove' }), null)
   })
 
-  t.test('parse with safe=true and constructorAction=remove returns null', t => {
+  await t.test('parse with safe=true and constructorAction=remove returns null', () => {
     const text = '{ "a": 5, "b": 6, "constructor": {"prototype": {"bar": "baz"}} }'
-    t.strictEqual(j.parse(text, { safe: true, constructorAction: 'remove' }), null)
-    t.end()
+    assert.strictEqual(j.parse(text, { safe: true, constructorAction: 'remove' }), null)
   })
 
-  t.test('parse with safe=false throws on __proto__', t => {
+  await t.test('parse with safe=false throws on __proto__', () => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'
-    t.throws(() => j.parse(text, { safe: false }), SyntaxError)
-    t.end()
+    assert.throws(() => j.parse(text, { safe: false }), SyntaxError)
   })
 
-  t.test('parse with safe=false throws on constructor', t => {
+  await t.test('parse with safe=false throws on constructor', () => {
     const text = '{ "a": 5, "b": 6, "constructor": {"prototype": {"bar": "baz"}} }'
-    t.throws(() => j.parse(text, { safe: false }), SyntaxError)
-    t.end()
+    assert.throws(() => j.parse(text, { safe: false }), SyntaxError)
   })
 
-  t.test('scan with safe=true returns null on __proto__', t => {
+  await t.test('scan with safe=true returns null on __proto__', () => {
     const obj = JSON.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }')
-    t.strictEqual(j.scan(obj, { safe: true }), null)
-    t.end()
+    assert.strictEqual(j.scan(obj, { safe: true }), null)
   })
 
-  t.test('scan with safe=true returns null on constructor', t => {
+  await t.test('scan with safe=true returns null on constructor', () => {
     const obj = JSON.parse('{ "a": 5, "b": 6, "constructor": {"prototype": {"bar": "baz"}} }')
-    t.strictEqual(j.scan(obj, { safe: true }), null)
-    t.end()
+    assert.strictEqual(j.scan(obj, { safe: true }), null)
   })
 
-  t.test('scan with safe=true returns object when valid', t => {
+  await t.test('scan with safe=true returns object when valid', () => {
     const obj = { a: 5, b: 6 }
-    t.deepEqual(j.scan(obj, { safe: true }), { a: 5, b: 6 })
-    t.end()
+    assert.deepEqual(j.scan(obj, { safe: true }), { a: 5, b: 6 })
   })
 
-  t.test('scan with safe=false throws on __proto__', t => {
+  await t.test('scan with safe=false throws on __proto__', () => {
     const obj = JSON.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }')
-    t.throws(() => j.scan(obj, { safe: false }), SyntaxError)
-    t.end()
+    assert.throws(() => j.scan(obj, { safe: false }), SyntaxError)
   })
 
-  t.test('scan with safe=false throws on constructor', t => {
+  await t.test('scan with safe=false throws on constructor', () => {
     const obj = JSON.parse('{ "a": 5, "b": 6, "constructor": {"prototype": {"bar": "baz"}} }')
-    t.throws(() => j.scan(obj, { safe: false }), SyntaxError)
-    t.end()
+    assert.throws(() => j.scan(obj, { safe: false }), SyntaxError)
   })
 
-  t.test('parse with safe=true returns null on nested __proto__', t => {
+  await t.test('parse with safe=true returns null on nested __proto__', () => {
     const text = '{ "a": 5, "c": { "d": 0, "__proto__": { "y": 8 } } }'
-    t.strictEqual(j.parse(text, { safe: true }), null)
-    t.end()
+    assert.strictEqual(j.parse(text, { safe: true }), null)
   })
 
-  t.test('parse with safe=true returns null on nested constructor', t => {
+  await t.test('parse with safe=true returns null on nested constructor', () => {
     const text = '{ "a": 5, "c": { "d": 0, "constructor": {"prototype": {"bar": "baz"}} } }'
-    t.strictEqual(j.parse(text, { safe: true }), null)
-    t.end()
+    assert.strictEqual(j.parse(text, { safe: true }), null)
   })
 
-  t.test('parse with safe=true and protoAction=ignore returns object', t => {
+  await t.test('parse with safe=true and protoAction=ignore returns object', () => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'
-    t.deepEqual(
+    assert.deepEqual(
       j.parse(text, { safe: true, protoAction: 'ignore' }),
       JSON.parse(text)
     )
-    t.end()
   })
 
-  t.test('parse with safe=true and constructorAction=ignore returns object', t => {
+  await t.test('parse with safe=true and constructorAction=ignore returns object', () => {
     const text = '{ "a": 5, "b": 6, "constructor": {"prototype": {"bar": "baz"}} }'
-    t.deepEqual(
+    assert.deepEqual(
       j.parse(text, { safe: true, constructorAction: 'ignore' }),
       JSON.parse(text)
     )
-    t.end()
   })
 
-  t.test('should reset stackTraceLimit with safe option', t => {
+  await t.test('should reset stackTraceLimit with safe option', () => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'
     Error.stackTraceLimit = 42
-    t.strictEqual(j.parse(text, { safe: true }), null)
-    t.same(Error.stackTraceLimit, 42)
-    t.end()
+    assert.strictEqual(j.parse(text, { safe: true }), null)
+    assert.strictEqual(Error.stackTraceLimit, 42)
   })
-
-  t.end()
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,233 +1,397 @@
 'use strict'
 
 const { test } = require('node:test')
-const assert = require('node:assert')
 const j = require('..')
 
 test('parse', async (t) => {
-  await t.test('parses object string', () => {
-    assert.deepEqual(
+  await t.test('parses object string', (t) => {
+    t.assert.deepStrictEqual(
       j.parse('{"a": 5, "b": 6}'),
       JSON.parse('{"a": 5, "b": 6}')
     )
   })
 
-  await t.test('parses null string', () => {
-    assert.strictEqual(j.parse('null'), JSON.parse('null'))
+  await t.test('parses null string', (t) => {
+    t.assert.strictEqual(j.parse('null'), JSON.parse('null'))
   })
 
-  await t.test('parses 0 string', () => {
-    assert.strictEqual(j.parse('0'), JSON.parse('0'))
+  await t.test('parses 0 string', (t) => {
+    t.assert.strictEqual(j.parse('0'), JSON.parse('0'))
   })
 
-  await t.test('parses string string', () => {
-    assert.strictEqual(j.parse('"X"'), JSON.parse('"X"'))
+  await t.test('parses string string', (t) => {
+    t.assert.strictEqual(j.parse('"X"'), JSON.parse('"X"'))
   })
 
-  await t.test('parses buffer', () => {
-    assert.strictEqual(
+  await t.test('parses buffer', (t) => {
+    t.assert.strictEqual(
       j.parse(Buffer.from('"X"')),
       JSON.parse(Buffer.from('"X"'))
     )
   })
 
-  await t.test('parses object string (reviver)', () => {
+  await t.test('parses object string (reviver)', (t) => {
     const reviver = (_key, value) => {
       return typeof value === 'number' ? value + 1 : value
     }
 
-    assert.deepEqual(
+    t.assert.deepStrictEqual(
       j.parse('{"a": 5, "b": 6}', reviver),
       JSON.parse('{"a": 5, "b": 6}', reviver)
     )
   })
 
   await t.test('protoAction', async (t) => {
-    await t.test('sanitizes object string (reviver, options)', () => {
+    await t.test('sanitizes object string (reviver, options)', (t) => {
       const reviver = (_key, value) => {
         return typeof value === 'number' ? value + 1 : value
       }
 
-      assert.deepEqual(
-        j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', reviver, { protoAction: 'remove' }),
+      t.assert.deepStrictEqual(
+        j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', reviver, {
+          protoAction: 'remove'
+        }),
         { a: 6, b: 7 }
       )
     })
 
-    await t.test('sanitizes object string (options)', () => {
-      assert.deepEqual(
-        j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', { protoAction: 'remove' }),
+    await t.test('sanitizes object string (options)', (t) => {
+      t.assert.deepStrictEqual(
+        j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', {
+          protoAction: 'remove'
+        }),
         { a: 5, b: 6 }
       )
     })
 
-    await t.test('sanitizes object string (null, options)', () => {
-      assert.deepEqual(
-        j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', null, { protoAction: 'remove' }),
+    await t.test('sanitizes object string (null, options)', (t) => {
+      t.assert.deepStrictEqual(
+        j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', null, {
+          protoAction: 'remove'
+        }),
         { a: 5, b: 6 }
       )
     })
 
-    await t.test('sanitizes object string (null, options)', () => {
-      assert.deepEqual(
-        j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', { protoAction: 'remove' }),
+    await t.test('sanitizes object string (null, options)', (t) => {
+      t.assert.deepStrictEqual(
+        j.parse('{"a": 5, "b": 6,"__proto__": { "x": 7 }}', {
+          protoAction: 'remove'
+        }),
         { a: 5, b: 6 }
       )
     })
 
-    await t.test('sanitizes nested object string', () => {
-      assert.deepEqual(
-        j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }', { protoAction: 'remove' }),
+    await t.test('sanitizes nested object string', (t) => {
+      t.assert.deepStrictEqual(
+        j.parse(
+          '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }',
+          { protoAction: 'remove' }
+        ),
         { a: 5, b: 6, c: { d: 0, e: 'text', f: { g: 2 } } }
       )
     })
 
-    await t.test('ignores proto property', () => {
-      assert.deepEqual(
-        j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }', { protoAction: 'ignore' }),
+    await t.test('ignores proto property', (t) => {
+      t.assert.deepStrictEqual(
+        j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }', {
+          protoAction: 'ignore'
+        }),
         JSON.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }')
       )
     })
 
-    await t.test('ignores proto value', () => {
-      assert.deepEqual(
-        j.parse('{"a": 5, "b": "__proto__"}'),
-        { a: 5, b: '__proto__' }
+    await t.test('ignores proto value', (t) => {
+      t.assert.deepStrictEqual(j.parse('{"a": 5, "b": "__proto__"}'), {
+        a: 5,
+        b: '__proto__'
+      })
+    })
+
+    await t.test('errors on proto property', (t) => {
+      t.assert.throws(
+        () => j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'),
+        SyntaxError
+      )
+      t.assert.throws(
+        () => j.parse('{ "a": 5, "b": 6, "__proto__" : { "x": 7 } }'),
+        SyntaxError
+      )
+      t.assert.throws(
+        () => j.parse('{ "a": 5, "b": 6, "__proto__" \n\r\t : { "x": 7 } }'),
+        SyntaxError
+      )
+      t.assert.throws(
+        () => j.parse('{ "a": 5, "b": 6, "__proto__" \n \r \t : { "x": 7 } }'),
+        SyntaxError
       )
     })
 
-    await t.test('errors on proto property', () => {
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'), SyntaxError)
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__" : { "x": 7 } }'), SyntaxError)
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__" \n\r\t : { "x": 7 } }'), SyntaxError)
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__" \n \r \t : { "x": 7 } }'), SyntaxError)
+    await t.test('errors on proto property (null, null)', (t) => {
+      t.assert.throws(
+        () =>
+          j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }', null, null),
+        SyntaxError
+      )
     })
 
-    await t.test('errors on proto property (null, null)', () => {
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }', null, null), SyntaxError)
+    await t.test('errors on proto property (explicit options)', (t) => {
+      t.assert.throws(
+        () =>
+          j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }', {
+            protoAction: 'error'
+          }),
+        SyntaxError
+      )
     })
 
-    await t.test('errors on proto property (explicit options)', () => {
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }', { protoAction: 'error' }), SyntaxError)
+    await t.test('errors on proto property (unicode)', (t) => {
+      t.assert.throws(
+        () => j.parse('{ "a": 5, "b": 6, "\\u005f_proto__": { "x": 7 } }'),
+        SyntaxError
+      )
+      t.assert.throws(
+        () =>
+          j.parse('{ "a": 5, "b": 6, "_\\u005fp\\u0072oto__": { "x": 7 } }'),
+        SyntaxError
+      )
+      t.assert.throws(
+        () =>
+          j.parse(
+            '{ "a": 5, "b": 6, "\\u005f\\u005f\\u0070\\u0072\\u006f\\u0074\\u006f\\u005f\\u005f": { "x": 7 } }'
+          ),
+        SyntaxError
+      )
+      t.assert.throws(
+        () => j.parse('{ "a": 5, "b": 6, "\\u005F_proto__": { "x": 7 } }'),
+        SyntaxError
+      )
+      t.assert.throws(
+        () =>
+          j.parse('{ "a": 5, "b": 6, "_\\u005Fp\\u0072oto__": { "x": 7 } }'),
+        SyntaxError
+      )
+      t.assert.throws(
+        () =>
+          j.parse(
+            '{ "a": 5, "b": 6, "\\u005F\\u005F\\u0070\\u0072\\u006F\\u0074\\u006F\\u005F\\u005F": { "x": 7 } }'
+          ),
+        SyntaxError
+      )
     })
 
-    await t.test('errors on proto property (unicode)', () => {
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005f_proto__": { "x": 7 } }'), SyntaxError)
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "_\\u005fp\\u0072oto__": { "x": 7 } }'), SyntaxError)
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005f\\u005f\\u0070\\u0072\\u006f\\u0074\\u006f\\u005f\\u005f": { "x": 7 } }'), SyntaxError)
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005F_proto__": { "x": 7 } }'), SyntaxError)
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "_\\u005Fp\\u0072oto__": { "x": 7 } }'), SyntaxError)
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "\\u005F\\u005F\\u0070\\u0072\\u006F\\u0074\\u006F\\u005F\\u005F": { "x": 7 } }'), SyntaxError)
-    })
-
-    await t.test('should reset stackTraceLimit', () => {
-      const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+    await t.test('should reset stackTraceLimit', (t) => {
+      const text =
+        '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
       Error.stackTraceLimit = 42
-      assert.throws(() => j.parse(text))
-      assert.strictEqual(Error.stackTraceLimit, 42)
+      t.assert.throws(() => j.parse(text))
+      t.assert.strictEqual(Error.stackTraceLimit, 42)
     })
   })
 
   await t.test('constructorAction', async (t) => {
-    await t.test('sanitizes object string (reviver, options)', () => {
+    await t.test('sanitizes object string (reviver, options)', (t) => {
       const reviver = (_key, value) => {
         return typeof value === 'number' ? value + 1 : value
       }
 
-      assert.deepEqual(
-        j.parse('{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }', reviver, { constructorAction: 'remove' }),
+      t.assert.deepStrictEqual(
+        j.parse(
+          '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }',
+          reviver,
+          { constructorAction: 'remove' }
+        ),
         { a: 6, b: 7 }
       )
     })
 
-    await t.test('sanitizes object string (options)', () => {
-      assert.deepEqual(
-        j.parse('{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }', { constructorAction: 'remove' }),
+    await t.test('sanitizes object string (options)', (t) => {
+      t.assert.deepStrictEqual(
+        j.parse(
+          '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }',
+          { constructorAction: 'remove' }
+        ),
         { a: 5, b: 6 }
       )
     })
 
-    await t.test('sanitizes object string (null, options)', () => {
-      assert.deepEqual(
-        j.parse('{"a": 5, "b": 6,"constructor":{"prototype":{"bar":"baz"}} }', null, { constructorAction: 'remove' }),
+    await t.test('sanitizes object string (null, options)', (t) => {
+      t.assert.deepStrictEqual(
+        j.parse(
+          '{"a": 5, "b": 6,"constructor":{"prototype":{"bar":"baz"}} }',
+          null,
+          { constructorAction: 'remove' }
+        ),
         { a: 5, b: 6 }
       )
     })
 
-    await t.test('sanitizes object string (null, options)', () => {
-      assert.deepEqual(
-        j.parse('{"a": 5, "b": 6,"constructor":{"prototype":{"bar":"baz"}} }', { constructorAction: 'remove' }),
+    await t.test('sanitizes object string (null, options)', (t) => {
+      t.assert.deepStrictEqual(
+        j.parse('{"a": 5, "b": 6,"constructor":{"prototype":{"bar":"baz"}} }', {
+          constructorAction: 'remove'
+        }),
         { a: 5, b: 6 }
       )
     })
 
-    await t.test('sanitizes object string (no prototype key)', () => {
-      assert.deepEqual(
-        j.parse('{"a": 5, "b": 6,"constructor":{"bar":"baz"} }', { constructorAction: 'remove' }),
+    await t.test('sanitizes object string (no prototype key)', (t) => {
+      t.assert.deepStrictEqual(
+        j.parse('{"a": 5, "b": 6,"constructor":{"bar":"baz"} }', {
+          constructorAction: 'remove'
+        }),
         { a: 5, b: 6, constructor: { bar: 'baz' } }
       )
     })
 
-    await t.test('sanitizes nested object string', () => {
-      assert.deepEqual(
-        j.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "c": { "d": 0, "e": "text", "constructor":{"prototype":{"bar":"baz"}}, "f": { "g": 2 } } }', { constructorAction: 'remove' }),
+    await t.test('sanitizes nested object string', (t) => {
+      t.assert.deepStrictEqual(
+        j.parse(
+          '{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "c": { "d": 0, "e": "text", "constructor":{"prototype":{"bar":"baz"}}, "f": { "g": 2 } } }',
+          { constructorAction: 'remove' }
+        ),
         { a: 5, b: 6, c: { d: 0, e: 'text', f: { g: 2 } } }
       )
     })
 
-    await t.test('ignores proto property', () => {
-      assert.deepEqual(
-        j.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }', { constructorAction: 'ignore' }),
-        JSON.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }')
+    await t.test('ignores proto property', (t) => {
+      t.assert.deepStrictEqual(
+        j.parse(
+          '{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }',
+          { constructorAction: 'ignore' }
+        ),
+        JSON.parse(
+          '{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }'
+        )
       )
     })
 
-    await t.test('ignores proto value', () => {
-      assert.deepEqual(
-        j.parse('{"a": 5, "b": "constructor"}'),
-        { a: 5, b: 'constructor' }
+    await t.test('ignores proto value', (t) => {
+      t.assert.deepStrictEqual(j.parse('{"a": 5, "b": "constructor"}'), {
+        a: 5,
+        b: 'constructor'
+      })
+    })
+
+    await t.test('errors on proto property', (t) => {
+      t.assert.throws(
+        () =>
+          j.parse(
+            '{ "a": 5, "b": 6, "constructor": {"prototype":{"bar":"baz"}} }'
+          ),
+        SyntaxError
+      )
+      t.assert.throws(
+        () =>
+          j.parse(
+            '{ "a": 5, "b": 6, "constructor" : {"prototype":{"bar":"baz"}} }'
+          ),
+        SyntaxError
+      )
+      t.assert.throws(
+        () =>
+          j.parse(
+            '{ "a": 5, "b": 6, "constructor" \n\r\t : {"prototype":{"bar":"baz"}} }'
+          ),
+        SyntaxError
+      )
+      t.assert.throws(
+        () =>
+          j.parse(
+            '{ "a": 5, "b": 6, "constructor" \n \r \t : {"prototype":{"bar":"baz"}} }'
+          ),
+        SyntaxError
       )
     })
 
-    await t.test('errors on proto property', () => {
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "constructor": {"prototype":{"bar":"baz"}} }'), SyntaxError)
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "constructor" : {"prototype":{"bar":"baz"}} }'), SyntaxError)
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "constructor" \n\r\t : {"prototype":{"bar":"baz"}} }'), SyntaxError)
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "constructor" \n \r \t : {"prototype":{"bar":"baz"}} }'), SyntaxError)
+    await t.test(
+      "should not throw if the constructor key hasn't a child named prototype",
+      (t) => {
+        t.assert.doesNotThrow(
+          () =>
+            j.parse(
+              '{ "a": 5, "b": 6, "constructor":{"bar":"baz"} }',
+              null,
+              null
+            ),
+          SyntaxError
+        )
+      }
+    )
+
+    await t.test('errors on proto property (null, null)', (t) => {
+      t.assert.throws(
+        () =>
+          j.parse(
+            '{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }',
+            null,
+            null
+          ),
+        SyntaxError
+      )
     })
 
-    await t.test("should not throw if the constructor key hasn't a child named prototype", () => {
-      assert.doesNotThrow(() => j.parse('{ "a": 5, "b": 6, "constructor":{"bar":"baz"} }', null, null), SyntaxError)
+    await t.test('errors on proto property (explicit options)', (t) => {
+      t.assert.throws(
+        () =>
+          j.parse(
+            '{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }',
+            { constructorAction: 'error' }
+          ),
+        SyntaxError
+      )
     })
 
-    await t.test('errors on proto property (null, null)', () => {
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }', null, null), SyntaxError)
+    await t.test('errors on proto property (unicode)', (t) => {
+      t.assert.throws(
+        () =>
+          j.parse(
+            '{ "a": 5, "b": 6, "\\u0063\\u006fnstructor": {"prototype":{"bar":"baz"}} }'
+          ),
+        SyntaxError
+      )
+      t.assert.throws(
+        () =>
+          j.parse(
+            '{ "a": 5, "b": 6, "\\u0063\\u006f\\u006e\\u0073\\u0074ructor": {"prototype":{"bar":"baz"}} }'
+          ),
+        SyntaxError
+      )
+      t.assert.throws(
+        () =>
+          j.parse(
+            '{ "a": 5, "b": 6, "\\u0063\\u006f\\u006e\\u0073\\u0074\\u0072\\u0075\\u0063\\u0074\\u006f\\u0072": {"prototype":{"bar":"baz"}} }'
+          ),
+        SyntaxError
+      )
+      t.assert.throws(
+        () =>
+          j.parse(
+            '{ "a": 5, "b": 6, "\\u0063\\u006Fnstructor": {"prototype":{"bar":"baz"}} }'
+          ),
+        SyntaxError
+      )
+      t.assert.throws(
+        () =>
+          j.parse(
+            '{ "a": 5, "b": 6, "\\u0063\\u006F\\u006E\\u0073\\u0074\\u0072\\u0075\\u0063\\u0074\\u006F\\u0072": {"prototype":{"bar":"baz"}} }'
+          ),
+        SyntaxError
+      )
     })
 
-    await t.test('errors on proto property (explicit options)', () => {
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }', { constructorAction: 'error' }), SyntaxError)
-    })
-
-    await t.test('errors on proto property (unicode)', () => {
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006fnstructor": {"prototype":{"bar":"baz"}} }'), SyntaxError)
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006f\\u006e\\u0073\\u0074ructor": {"prototype":{"bar":"baz"}} }'), SyntaxError)
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006f\\u006e\\u0073\\u0074\\u0072\\u0075\\u0063\\u0074\\u006f\\u0072": {"prototype":{"bar":"baz"}} }'), SyntaxError)
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006Fnstructor": {"prototype":{"bar":"baz"}} }'), SyntaxError)
-      assert.throws(() => j.parse('{ "a": 5, "b": 6, "\\u0063\\u006F\\u006E\\u0073\\u0074\\u0072\\u0075\\u0063\\u0074\\u006F\\u0072": {"prototype":{"bar":"baz"}} }'), SyntaxError)
-    })
-
-    await t.test('handles constructor null safely', () => {
-      assert.deepEqual(
+    await t.test('handles constructor null safely', (t) => {
+      t.assert.deepStrictEqual(
         j.parse('{"constructor": null}', { constructorAction: 'remove' }),
         { constructor: null }
       )
 
-      assert.deepEqual(
+      t.assert.deepStrictEqual(
         j.parse('{"constructor": null}', { constructorAction: 'error' }),
         { constructor: null }
       )
 
-      assert.deepEqual(
+      t.assert.deepStrictEqual(
         j.parse('{"constructor": null}', { constructorAction: 'ignore' }),
         { constructor: null }
       )
@@ -235,8 +399,8 @@ test('parse', async (t) => {
   })
 
   await t.test('protoAction and constructorAction', async (t) => {
-    await t.test('protoAction=remove constructorAction=remove', () => {
-      assert.deepEqual(
+    await t.test('protoAction=remove constructorAction=remove', (t) => {
+      t.assert.deepStrictEqual(
         j.parse(
           '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
           { protoAction: 'remove', constructorAction: 'remove' }
@@ -245,8 +409,8 @@ test('parse', async (t) => {
       )
     })
 
-    await t.test('protoAction=ignore constructorAction=remove', () => {
-      assert.deepEqual(
+    await t.test('protoAction=ignore constructorAction=remove', (t) => {
+      t.assert.deepStrictEqual(
         j.parse(
           '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
           { protoAction: 'ignore', constructorAction: 'remove' }
@@ -255,280 +419,342 @@ test('parse', async (t) => {
       )
     })
 
-    await t.test('protoAction=remove constructorAction=ignore', () => {
-      assert.deepEqual(
+    await t.test('protoAction=remove constructorAction=ignore', (t) => {
+      t.assert.deepStrictEqual(
         j.parse(
           '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
           { protoAction: 'remove', constructorAction: 'ignore' }
         ),
-        JSON.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }')
+        JSON.parse(
+          '{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }'
+        )
       )
     })
 
-    await t.test('protoAction=ignore constructorAction=ignore', () => {
-      assert.deepEqual(
+    await t.test('protoAction=ignore constructorAction=ignore', (t) => {
+      t.assert.deepStrictEqual(
         j.parse(
           '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
           { protoAction: 'ignore', constructorAction: 'ignore' }
         ),
-        JSON.parse('{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }')
+        JSON.parse(
+          '{ "a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }'
+        )
       )
     })
 
-    await t.test('protoAction=error constructorAction=ignore', () => {
-      assert.throws(() => j.parse(
-        '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
-        { protoAction: 'error', constructorAction: 'ignore' }
-      ), SyntaxError)
+    await t.test('protoAction=error constructorAction=ignore', (t) => {
+      t.assert.throws(
+        () =>
+          j.parse(
+            '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
+            { protoAction: 'error', constructorAction: 'ignore' }
+          ),
+        SyntaxError
+      )
     })
 
-    await t.test('protoAction=ignore constructorAction=error', () => {
-      assert.throws(() => j.parse(
-        '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
-        { protoAction: 'ignore', constructorAction: 'error' }
-      ), SyntaxError)
+    await t.test('protoAction=ignore constructorAction=error', (t) => {
+      t.assert.throws(
+        () =>
+          j.parse(
+            '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
+            { protoAction: 'ignore', constructorAction: 'error' }
+          ),
+        SyntaxError
+      )
     })
 
-    await t.test('protoAction=error constructorAction=error', () => {
-      assert.throws(() => j.parse(
-        '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
-        { protoAction: 'error', constructorAction: 'error' }
-      ), SyntaxError)
+    await t.test('protoAction=error constructorAction=error', (t) => {
+      t.assert.throws(
+        () =>
+          j.parse(
+            '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}}, "__proto__": { "x": 7 } }',
+            { protoAction: 'error', constructorAction: 'error' }
+          ),
+        SyntaxError
+      )
     })
   })
 
-  await t.test('sanitizes nested object string', () => {
-    const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+  await t.test('sanitizes nested object string', (t) => {
+    const text =
+      '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
     const obj = j.parse(text, { protoAction: 'remove' })
-    assert.deepEqual(obj, { a: 5, b: 6, c: { d: 0, e: 'text', f: { g: 2 } } })
+    t.assert.deepStrictEqual(obj, {
+      a: 5,
+      b: 6,
+      c: { d: 0, e: 'text', f: { g: 2 } }
+    })
   })
 
-  await t.test('errors on constructor property', () => {
-    const text = '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-    assert.throws(() => j.parse(text), SyntaxError)
+  await t.test('errors on constructor property', (t) => {
+    const text =
+      '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+    t.assert.throws(() => j.parse(text), SyntaxError)
   })
 
-  await t.test('errors on proto property', () => {
-    const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-    assert.throws(() => j.parse(text), SyntaxError)
+  await t.test('errors on proto property', (t) => {
+    const text =
+      '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+    t.assert.throws(() => j.parse(text), SyntaxError)
   })
 
-  await t.test('errors on constructor property', () => {
-    const text = '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-    assert.throws(() => j.parse(text), SyntaxError)
+  await t.test('errors on constructor property', (t) => {
+    const text =
+      '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+    t.assert.throws(() => j.parse(text), SyntaxError)
   })
 
-  await t.test('does not break when hasOwnProperty is overwritten', () => {
-    const text = '{ "a": 5, "b": 6, "hasOwnProperty": "text", "__proto__": { "x": 7 } }'
+  await t.test('does not break when hasOwnProperty is overwritten', (t) => {
+    const text =
+      '{ "a": 5, "b": 6, "hasOwnProperty": "text", "__proto__": { "x": 7 } }'
     const obj = j.parse(text, { protoAction: 'remove' })
-    assert.deepEqual(obj, { a: 5, b: 6, hasOwnProperty: 'text' })
+    t.assert.deepStrictEqual(obj, { a: 5, b: 6, hasOwnProperty: 'text' })
   })
 })
 
 test('safeParse', async (t) => {
-  await t.test('parses buffer', () => {
-    assert.strictEqual(
+  await t.test('parses buffer', (t) => {
+    t.assert.strictEqual(
       j.safeParse(Buffer.from('"X"')),
       JSON.parse(Buffer.from('"X"'))
     )
   })
 
-  await t.test('should reset stackTraceLimit', () => {
-    const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+  await t.test('should reset stackTraceLimit', (t) => {
+    const text =
+      '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
     Error.stackTraceLimit = 42
-    assert.strictEqual(j.safeParse(text), null)
-    assert.strictEqual(Error.stackTraceLimit, 42)
+    t.assert.strictEqual(j.safeParse(text), null)
+    t.assert.strictEqual(Error.stackTraceLimit, 42)
   })
 
-  await t.test('sanitizes nested object string', () => {
-    const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-    assert.strictEqual(j.safeParse(text), null)
+  await t.test('sanitizes nested object string', (t) => {
+    const text =
+      '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+    t.assert.strictEqual(j.safeParse(text), null)
   })
 
-  await t.test('returns null on constructor property', () => {
-    const text = '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-    assert.strictEqual(j.safeParse(text), null)
+  await t.test('returns null on constructor property', (t) => {
+    const text =
+      '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+    t.assert.strictEqual(j.safeParse(text), null)
   })
 
-  await t.test('returns null on proto property', () => {
-    const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-    assert.strictEqual(j.safeParse(text), null)
+  await t.test('returns null on proto property', (t) => {
+    const text =
+      '{ "a": 5, "b": 6, "__proto__": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+    t.assert.strictEqual(j.safeParse(text), null)
   })
 
-  await t.test('returns null on constructor property', () => {
-    const text = '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
-    assert.strictEqual(j.safeParse(text), null)
+  await t.test('returns null on constructor property', (t) => {
+    const text =
+      '{ "a": 5, "b": 6, "constructor": { "x": 7 }, "c": { "d": 0, "e": "text", "__proto__": { "y": 8 }, "f": { "g": 2 } } }'
+    t.assert.strictEqual(j.safeParse(text), null)
   })
 
-  await t.test('parses object string', () => {
-    assert.deepEqual(j.safeParse('{"a": 5, "b": 6}'), { a: 5, b: 6 })
+  await t.test('parses object string', (t) => {
+    t.assert.deepStrictEqual(j.safeParse('{"a": 5, "b": 6}'), { a: 5, b: 6 })
   })
 
-  await t.test('returns null on proto object string', () => {
-    assert.strictEqual(
+  await t.test('returns null on proto object string', (t) => {
+    t.assert.strictEqual(
       j.safeParse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'),
       null
     )
   })
 
-  await t.test('returns undefined on invalid object string', () => {
-    assert.strictEqual(j.safeParse('{"a": 5, "b": 6'), undefined)
+  await t.test('returns undefined on invalid object string', (t) => {
+    t.assert.strictEqual(j.safeParse('{"a": 5, "b": 6'), undefined)
   })
 
-  await t.test('sanitizes object string (options)', () => {
-    assert.strictEqual(
-      j.safeParse('{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }'),
+  await t.test('sanitizes object string (options)', (t) => {
+    t.assert.strictEqual(
+      j.safeParse(
+        '{"a": 5, "b": 6, "constructor":{"prototype":{"bar":"baz"}} }'
+      ),
       null
     )
   })
 
-  await t.test('sanitizes object string (no prototype key)', () => {
-    assert.deepEqual(
+  await t.test('sanitizes object string (no prototype key)', (t) => {
+    t.assert.deepStrictEqual(
       j.safeParse('{"a": 5, "b": 6,"constructor":{"bar":"baz"} }'),
       { a: 5, b: 6, constructor: { bar: 'baz' } }
     )
   })
 })
 
-test('parse string with BOM', () => {
+test('parse string with BOM', (t) => {
   const theJson = { hello: 'world' }
   const buffer = Buffer.concat([
     Buffer.from([239, 187, 191]), // the utf8 BOM
     Buffer.from(JSON.stringify(theJson))
   ])
-  assert.deepEqual(j.parse(buffer.toString()), theJson)
+  t.assert.deepStrictEqual(j.parse(buffer.toString()), theJson)
 })
 
-test('parse buffer with BOM', () => {
+test('parse buffer with BOM', (t) => {
   const theJson = { hello: 'world' }
   const buffer = Buffer.concat([
     Buffer.from([239, 187, 191]), // the utf8 BOM
     Buffer.from(JSON.stringify(theJson))
   ])
-  assert.deepEqual(j.parse(buffer), theJson)
+  t.assert.deepStrictEqual(j.parse(buffer), theJson)
 })
 
-test('safeParse string with BOM', () => {
+test('safeParse string with BOM', (t) => {
   const theJson = { hello: 'world' }
   const buffer = Buffer.concat([
     Buffer.from([239, 187, 191]), // the utf8 BOM
     Buffer.from(JSON.stringify(theJson))
   ])
-  assert.deepEqual(j.safeParse(buffer.toString()), theJson)
+  t.assert.deepStrictEqual(j.safeParse(buffer.toString()), theJson)
 })
 
-test('safeParse buffer with BOM', () => {
+test('safeParse buffer with BOM', (t) => {
   const theJson = { hello: 'world' }
   const buffer = Buffer.concat([
     Buffer.from([239, 187, 191]), // the utf8 BOM
     Buffer.from(JSON.stringify(theJson))
   ])
-  assert.deepEqual(j.safeParse(buffer), theJson)
+  t.assert.deepStrictEqual(j.safeParse(buffer), theJson)
 })
 
-test('scan handles optional options', () => {
-  assert.doesNotThrow(() => j.scan({ a: 'b' }))
+test('scan handles optional options', (t) => {
+  t.assert.doesNotThrow(() => j.scan({ a: 'b' }))
 })
 
 test('safe option', async (t) => {
-  await t.test('parse with safe=true returns null on __proto__', () => {
+  await t.test('parse with safe=true returns null on __proto__', (t) => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'
-    assert.strictEqual(j.parse(text, { safe: true }), null)
+    t.assert.strictEqual(j.parse(text, { safe: true }), null)
   })
 
-  await t.test('parse with safe=true returns null on constructor', () => {
-    const text = '{ "a": 5, "b": 6, "constructor": {"prototype": {"bar": "baz"}} }'
-    assert.strictEqual(j.parse(text, { safe: true }), null)
+  await t.test('parse with safe=true returns null on constructor', (t) => {
+    const text =
+      '{ "a": 5, "b": 6, "constructor": {"prototype": {"bar": "baz"}} }'
+    t.assert.strictEqual(j.parse(text, { safe: true }), null)
   })
 
-  await t.test('parse with safe=true returns object when valid', () => {
+  await t.test('parse with safe=true returns object when valid', (t) => {
     const text = '{ "a": 5, "b": 6 }'
-    assert.deepEqual(j.parse(text, { safe: true }), { a: 5, b: 6 })
+    t.assert.deepStrictEqual(j.parse(text, { safe: true }), { a: 5, b: 6 })
   })
 
-  await t.test('parse with safe=true and reviver', () => {
+  await t.test('parse with safe=true and reviver', (t) => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'
     const reviver = (_key, value) => {
       return typeof value === 'number' ? value + 1 : value
     }
-    assert.strictEqual(j.parse(text, reviver, { safe: true }), null)
+    t.assert.strictEqual(j.parse(text, reviver, { safe: true }), null)
   })
 
-  await t.test('parse with safe=true and protoAction=remove returns null', () => {
+  await t.test(
+    'parse with safe=true and protoAction=remove returns null',
+    (t) => {
+      const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'
+      t.assert.strictEqual(
+        j.parse(text, { safe: true, protoAction: 'remove' }),
+        null
+      )
+    }
+  )
+
+  await t.test(
+    'parse with safe=true and constructorAction=remove returns null',
+    (t) => {
+      const text =
+        '{ "a": 5, "b": 6, "constructor": {"prototype": {"bar": "baz"}} }'
+      t.assert.strictEqual(
+        j.parse(text, { safe: true, constructorAction: 'remove' }),
+        null
+      )
+    }
+  )
+
+  await t.test('parse with safe=false throws on __proto__', (t) => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'
-    assert.strictEqual(j.parse(text, { safe: true, protoAction: 'remove' }), null)
+    t.assert.throws(() => j.parse(text, { safe: false }), SyntaxError)
   })
 
-  await t.test('parse with safe=true and constructorAction=remove returns null', () => {
-    const text = '{ "a": 5, "b": 6, "constructor": {"prototype": {"bar": "baz"}} }'
-    assert.strictEqual(j.parse(text, { safe: true, constructorAction: 'remove' }), null)
+  await t.test('parse with safe=false throws on constructor', (t) => {
+    const text =
+      '{ "a": 5, "b": 6, "constructor": {"prototype": {"bar": "baz"}} }'
+    t.assert.throws(() => j.parse(text, { safe: false }), SyntaxError)
   })
 
-  await t.test('parse with safe=false throws on __proto__', () => {
-    const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'
-    assert.throws(() => j.parse(text, { safe: false }), SyntaxError)
-  })
-
-  await t.test('parse with safe=false throws on constructor', () => {
-    const text = '{ "a": 5, "b": 6, "constructor": {"prototype": {"bar": "baz"}} }'
-    assert.throws(() => j.parse(text, { safe: false }), SyntaxError)
-  })
-
-  await t.test('scan with safe=true returns null on __proto__', () => {
+  await t.test('scan with safe=true returns null on __proto__', (t) => {
     const obj = JSON.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }')
-    assert.strictEqual(j.scan(obj, { safe: true }), null)
+    t.assert.strictEqual(j.scan(obj, { safe: true }), null)
   })
 
-  await t.test('scan with safe=true returns null on constructor', () => {
-    const obj = JSON.parse('{ "a": 5, "b": 6, "constructor": {"prototype": {"bar": "baz"}} }')
-    assert.strictEqual(j.scan(obj, { safe: true }), null)
+  await t.test('scan with safe=true returns null on constructor', (t) => {
+    const obj = JSON.parse(
+      '{ "a": 5, "b": 6, "constructor": {"prototype": {"bar": "baz"}} }'
+    )
+    t.assert.strictEqual(j.scan(obj, { safe: true }), null)
   })
 
-  await t.test('scan with safe=true returns object when valid', () => {
+  await t.test('scan with safe=true returns object when valid', (t) => {
     const obj = { a: 5, b: 6 }
-    assert.deepEqual(j.scan(obj, { safe: true }), { a: 5, b: 6 })
+    t.assert.deepStrictEqual(j.scan(obj, { safe: true }), { a: 5, b: 6 })
   })
 
-  await t.test('scan with safe=false throws on __proto__', () => {
+  await t.test('scan with safe=false throws on __proto__', (t) => {
     const obj = JSON.parse('{ "a": 5, "b": 6, "__proto__": { "x": 7 } }')
-    assert.throws(() => j.scan(obj, { safe: false }), SyntaxError)
+    t.assert.throws(() => j.scan(obj, { safe: false }), SyntaxError)
   })
 
-  await t.test('scan with safe=false throws on constructor', () => {
-    const obj = JSON.parse('{ "a": 5, "b": 6, "constructor": {"prototype": {"bar": "baz"}} }')
-    assert.throws(() => j.scan(obj, { safe: false }), SyntaxError)
+  await t.test('scan with safe=false throws on constructor', (t) => {
+    const obj = JSON.parse(
+      '{ "a": 5, "b": 6, "constructor": {"prototype": {"bar": "baz"}} }'
+    )
+    t.assert.throws(() => j.scan(obj, { safe: false }), SyntaxError)
   })
 
-  await t.test('parse with safe=true returns null on nested __proto__', () => {
+  await t.test('parse with safe=true returns null on nested __proto__', (t) => {
     const text = '{ "a": 5, "c": { "d": 0, "__proto__": { "y": 8 } } }'
-    assert.strictEqual(j.parse(text, { safe: true }), null)
+    t.assert.strictEqual(j.parse(text, { safe: true }), null)
   })
 
-  await t.test('parse with safe=true returns null on nested constructor', () => {
-    const text = '{ "a": 5, "c": { "d": 0, "constructor": {"prototype": {"bar": "baz"}} } }'
-    assert.strictEqual(j.parse(text, { safe: true }), null)
-  })
+  await t.test(
+    'parse with safe=true returns null on nested constructor',
+    (t) => {
+      const text =
+        '{ "a": 5, "c": { "d": 0, "constructor": {"prototype": {"bar": "baz"}} } }'
+      t.assert.strictEqual(j.parse(text, { safe: true }), null)
+    }
+  )
 
-  await t.test('parse with safe=true and protoAction=ignore returns object', () => {
-    const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'
-    assert.deepEqual(
-      j.parse(text, { safe: true, protoAction: 'ignore' }),
-      JSON.parse(text)
-    )
-  })
+  await t.test(
+    'parse with safe=true and protoAction=ignore returns object',
+    (t) => {
+      const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'
+      t.assert.deepStrictEqual(
+        j.parse(text, { safe: true, protoAction: 'ignore' }),
+        JSON.parse(text)
+      )
+    }
+  )
 
-  await t.test('parse with safe=true and constructorAction=ignore returns object', () => {
-    const text = '{ "a": 5, "b": 6, "constructor": {"prototype": {"bar": "baz"}} }'
-    assert.deepEqual(
-      j.parse(text, { safe: true, constructorAction: 'ignore' }),
-      JSON.parse(text)
-    )
-  })
+  await t.test(
+    'parse with safe=true and constructorAction=ignore returns object',
+    (t) => {
+      const text =
+        '{ "a": 5, "b": 6, "constructor": {"prototype": {"bar": "baz"}} }'
+      t.assert.deepStrictEqual(
+        j.parse(text, { safe: true, constructorAction: 'ignore' }),
+        JSON.parse(text)
+      )
+    }
+  )
 
-  await t.test('should reset stackTraceLimit with safe option', () => {
+  await t.test('should reset stackTraceLimit with safe option', (t) => {
     const text = '{ "a": 5, "b": 6, "__proto__": { "x": 7 } }'
     Error.stackTraceLimit = 42
-    assert.strictEqual(j.parse(text, { safe: true }), null)
-    assert.strictEqual(Error.stackTraceLimit, 42)
+    t.assert.strictEqual(j.parse(text, { safe: true }), null)
+    t.assert.strictEqual(Error.stackTraceLimit, 42)
   })
 })


### PR DESCRIPTION
Proposal:

This PR migrates the test suite from `tape` to the native `node:test` runner and node:assert module. Since tape is no longer actively maintained and Node.js now provides a robust built-in testing solution, this migration reduces external dependencies and align the project with other repositories in the fastify ecosystem 

Changes made:

- Migrate tests from `tape` to `node:test`
- Removed `airtap`, `airtap-playwright` with `node:test` along with `playwright` 
